### PR TITLE
Fixed cut bug

### DIFF
--- a/src/DrawArea.vala
+++ b/src/DrawArea.vala
@@ -1743,7 +1743,9 @@ public class DrawArea : Gtk.DrawingArea {
   /* Cuts the current selected text to the clipboard */
   private void cut_selected_text() {
     copy_selected_text();
-    _current_node.edit_delete( _layout );
+    _current_node.edit_insert("", _layout );
+    queue_draw();
+    changed();
   }
 
   /* Either cuts the current node or cuts the currently selected text */


### PR DESCRIPTION
Fix _cut_selected_text()_:
- The node wasn't redrawn after cutting text.
- The behavior of the function without selected text was unusual and counter intuitive, it deleted the character at the right of the cursor.