### PR TITLE
Fix post_install.py script

### DIFF
--- a/meson/post_install.py
+++ b/meson/post_install.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 
-import os
+from os import path, environ
 import subprocess
 
-if not os.environ.get('DESTDIR'):
-    print('Compiling gsettings schemas…')
-    schemadir  = os.path.join(os.environ['MESON_INSTALL_PREFIX'], 'share', 'glib-2.0', 'schemas')
-    subprocess.call(['glib-compile-schemas', schemadir], shell=False)
+prefix = environ.get('MESON_INSTALL_PREFIX', '/usr/local')
+schemadir = path.join(environ['MESON_INSTALL_PREFIX'], 'share', 'glib-2.0', 'schemas')
+datadir = path.join(prefix, 'share')
 
+if not environ.get('DESTDIR'):
+    print('Compiling gsettings schemas…')
+    subprocess.call(['glib-compile-schemas', schemadir])
+    print('Updating icon cache…')
+    subprocess.call(['gtk-update-icon-cache', '-qtf', path.join(datadir, 'icons', 'hicolor')])
     print('Compiling mime types…')
-    mimedir = os.path.join(os.environ['MESON_INSTALL_PREFIX'], 'share', 'mime')
-    subprocess.call(['update-mime-database', mimedir], shell=False)
+    subprocess.call(['update-mime-database', path.join(datadir, 'mime')])


### PR DESCRIPTION
There was a problem with the `post_install.py` script. It wasn't updating the icon cache so Minder didn't have it's icon loaded.

So I have rewrited the script to fix this.

**This PR is ready for review**