### PR TITLE
Remove unused libarchive dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -51,7 +51,6 @@ dependencies = [
     dependency('granite'),
     dependency('gtk+-3.0'),
     dependency('libxml-2.0'),
-    dependency('libarchive'),
     math_dep
 ]
 


### PR DESCRIPTION
It seems to be unused. For the FreeBSD package I'm currently patching `meson.build` to remove it to no ill effect that I can observe.

Do we actually need it?