### PR TITLE
* Fixing sidebar hiding

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -190,7 +190,7 @@ public class MainWindow : ApplicationWindow {
     /* Create the panel so that we can resize */
     _pane = new Paned( Orientation.HORIZONTAL );
     _pane.pack1( _nb,        true, true );
-    _pane.pack2( _inspector, true, false );
+    _pane.pack2( _inspector, false, false );
     _pane.move_handle.connect(() => {
       return( false );
     });


### PR DESCRIPTION
Disable resize of right pane (sidebar) as it does not seems to be need, and consequencially it fixes sidebar hiding.

https://developer.gnome.org/gtk3/stable/GtkPaned.html#gtk-paned-pack2

Related to issue #108

PS: This might not be a proper fix.