### PR TITLE
Keep affects selection intact if in range of possible values

### DIFF
--- a/src/StyleInspector.vala
+++ b/src/StyleInspector.vala
@@ -1166,7 +1166,9 @@ public class StyleInspector : Box {
       }
     }
     if( (nodes > 0) || (conns > 0) ) {
-      set_affects( StyleAffects.CURRENT );
+      if( (nodes != 1) && (_affects > StyleAffects.CURRENT) ) {
+        set_affects( StyleAffects.CURRENT );
+      }
     } else {
       set_affects( StyleAffects.ALL );
     }


### PR DESCRIPTION
Keep the "Change affects" selection intact if the selected value is
in range of possible values.

This prevents the selection to be reset each time there is a change
to style.  For example if a single node is selected and the affects
is set to "ALL".

I wasn't able make it to preselect "Current" when selecting a node(s). It would possibly require more signals from `DrawArea`.