### PR TITLE
Improve node markup handling

### DIFF
--- a/src/CanvasText.vala
+++ b/src/CanvasText.vala
@@ -227,7 +227,7 @@ public class CanvasText : Object {
 
   /* Generates the marked up name that will be displayed in the node */
   private string name_markup() {
-    return( (markup || edit) ? text : unmarkup( text ) );
+    return( (markup && !edit) ? text : unmarkup( text ) );
   }
 
   /* Render the text, adding any necessary attributes to the text layout */

--- a/src/Node.vala
+++ b/src/Node.vala
@@ -254,6 +254,7 @@ public class Node : Object {
     set {
       if( _style.copy( value ) ) {
         name.set_font( _style.node_font );
+        name.markup = _style.node_markup;
         position_name();
       }
     }
@@ -846,6 +847,7 @@ public class Node : Object {
   private void load_style( Xml.Node* n ) {
     _style.load_node( n );
     _name.set_font( _style.node_font );
+    _name.markup = _style.node_markup;
   }
 
   /* Loads the URL links information from the given XML node */


### PR DESCRIPTION
Fixes Node markup setting and allows to edit the markup in text mode. 
Resolves Pango warnings "not a valid character" while writing markup.

PS: I was unable to fix URL highlighting, as the positions are taken from the markup string and not from the visual text. Highlight is then shifted.
