### PR TITLE
Update French translations + Few fixes

### DIFF
--- a/data/com.github.phase1geo.minder.appdata.xml.in
+++ b/data/com.github.phase1geo.minder.appdata.xml.in
@@ -24,7 +24,7 @@
       <li>Built-in and customizable theming.</li>
       <li>Gorgeous animations.</li>
       <li>Import from OPML, FreeMind, Freeplane, PlainText (formatted), Outliner and Portable Minder formats.</li>
-      <li>Export to CSV, FreeMind, Freeplane, JPEG, BMP, SVG, Markdown, Mermaid, OPML, Org-Mode, Outliner, PDF, PNG, Portable Minder, SVG, PlainText and yEd formats.</li>
+      <li>Export to CSV, FreeMind, Freeplane, JPEG, BMP, SVG, Markdown, Mermaid, OPML, Org-Mode, Outliner, PDF, PNG, Portable Minder, PlainText and yEd formats.</li>
       <li>Printer support.</li>
     </ul>
   </description>
@@ -106,7 +106,7 @@
         </ul>
         <p>Bug Fixes</p>
         <ul>
-          <li>Fixed Travis CI version.</li>
+          <li>Fixed NodeJS version for Travis CI.</li>
           <li>Fixed issue with adding a new child node that doesn't cause other descendant nodes to unfold.</li>
           <li>Fixed issue with showing/hiding sidebar.</li>
           <li>Fixed segmentation faults when loading a theme.</li>

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -2,6 +2,7 @@ src/NodeMenu.vala
 src/EmptyMenu.vala
 src/ConnectionMenu.vala
 src/DrawArea.vala
+src/Document.vala
 src/ImageEditor.vala
 
 src/layouts/LayoutManual.vala

--- a/po/com.github.phase1geo.minder.pot
+++ b/po/com.github.phase1geo.minder.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.phase1geo.minder\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-15 04:19-0500\n"
+"POT-Creation-Date: 2020-04-15 19:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -233,6 +233,10 @@ msgstr ""
 
 #: src/DrawArea.vala:2582
 msgid "unfold all tasks"
+msgstr ""
+
+#: src/Document.vala:65
+msgid "unnamed"
 msgstr ""
 
 #: src/ImageEditor.vala:179

--- a/po/extra/POTFILES
+++ b/po/extra/POTFILES
@@ -1,2 +1,2 @@
-data/com.github.phase1geo.minder.appdata.xml.in
 data/com.github.phase1geo.minder.desktop.in
+data/com.github.phase1geo.minder.appdata.xml.in

--- a/po/extra/fr.po
+++ b/po/extra/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-12 11:55+0100\n"
+"POT-Creation-Date: 2020-04-15 19:18+0200\n"
 "PO-Revision-Date: 2019-03-24 15:37+0100\n"
 "Last-Translator: Nathan Bonnemains (@NathanBnm)\n"
 "Language-Team: none\n"
@@ -17,15 +17,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:7
 #: data/com.github.phase1geo.minder.desktop.in:3
+#: data/com.github.phase1geo.minder.appdata.xml.in:7
 msgid "Minder"
 msgstr "Minder"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:8
+#: data/com.github.phase1geo.minder.desktop.in:4
+msgid "Mind-mapper"
+msgstr "Créateur de cartes mentales"
+
 #: data/com.github.phase1geo.minder.desktop.in:5
+#: data/com.github.phase1geo.minder.appdata.xml.in:8
 msgid "Create, develop and visualize your ideas"
 msgstr "Créez, développez et visualisez vos idées"
+
+#: data/com.github.phase1geo.minder.desktop.in:8
+msgid "com.github.phase1geo.minder"
+msgstr "com.github.phase1geo.minder"
+
+#: data/com.github.phase1geo.minder.desktop.in:14
+msgid "Mind;Mapping;"
+msgstr "Mentale;Carte;"
+
+#: data/com.github.phase1geo.minder.desktop.in:18
+msgid "New Document"
+msgstr "Nouveau document"
 
 #: data/com.github.phase1geo.minder.appdata.xml.in:10
 msgid "Use the power of mind-mapping to make your ideas come to life."
@@ -106,16 +122,21 @@ msgid "Gorgeous animations."
 msgstr "Magnifiques animations."
 
 #: data/com.github.phase1geo.minder.appdata.xml.in:26
-msgid "Import from OPML, FreeMind and Freeplane formats."
-msgstr "Importation à partir des formats OPML, FreeMind et Freeplane."
+msgid ""
+"Import from OPML, FreeMind, Freeplane, PlainText (formatted), Outliner and "
+"Portable Minder formats."
+msgstr ""
+"Importation depuis les formats OPML, FreeMind et Freeplane, Texte brut (mis "
+"en forme), Outliner et Minder portable."
 
 #: data/com.github.phase1geo.minder.appdata.xml.in:27
 msgid ""
-"Export to PDF, PNG, JPEG, BMP, SVG, OPML, CSV, Markdown, PlainText, "
-"FreeMind, Freeplane, yEd and Mermaid formats."
+"Export to CSV, FreeMind, Freeplane, JPEG, BMP, SVG, Markdown, Mermaid, OPML, "
+"Org-Mode, Outliner, PDF, PNG, Portable Minder, PlainText and yEd formats."
 msgstr ""
-"Exportez aux formats PDF, PNG, JPEG, BMP, SVG, OPML, CSV, Markdown, Texte "
-"brut, FreeMind, Freeplane, yEd et Mermaid."
+"Exportation aux formats CSV, FreeMind, Freeplane, JPEG, BMP, SVG, Markdown, "
+"Mermaid, OPML, Org-Mode, Outliner, PDF, PNG, Minder portable, Texte brut et "
+"yEd."
 
 #: data/com.github.phase1geo.minder.appdata.xml.in:28
 msgid "Printer support."
@@ -138,12 +159,167 @@ msgid "Trevor Williams"
 msgstr "Trevor Williams"
 
 #: data/com.github.phase1geo.minder.appdata.xml.in:88
-#: data/com.github.phase1geo.minder.appdata.xml.in:137
-#: data/com.github.phase1geo.minder.appdata.xml.in:173
+#: data/com.github.phase1geo.minder.appdata.xml.in:122
+#: data/com.github.phase1geo.minder.appdata.xml.in:171
+#: data/com.github.phase1geo.minder.appdata.xml.in:207
 msgid "New"
 msgstr "Nouveau"
 
 #: data/com.github.phase1geo.minder.appdata.xml.in:90
+msgid ""
+"Added support for importing/exporting Outliner files (new app in AppCenter!)."
+msgstr ""
+"Ajout de la prise en charge de l'importation/exportation au format Outliner "
+"(nouvelle application dans le Centre d'Applications !)."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:91
+msgid ""
+"Added map inspector switch to enable/disable automatic rotation of main "
+"branch link color selection."
+msgstr ""
+"Ajout d'un inspecteur de carte pour activer/désactiver la rotation "
+"automatique de la couleur de sélection du lien de la branche principale."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:92
+msgid "Added ability to set all selected nodes to a specific color."
+msgstr ""
+"Ajout de la possibilité de définir une couleur spécifique pour tous les "
+"nœuds sélectionnés."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:93
+msgid ""
+"Added ability to set all selected nodes to a randomly selected link color."
+msgstr ""
+"Ajout de la possibilité de définir une couleur de lien sélectionné aléatoire "
+"pour tous les nœuds sélectionnés"
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:94
+msgid ""
+"Added ability to allow descendant nodes to have different link colors than "
+"ancestor nodes."
+msgstr ""
+"Ajout de la possibilité aux nœuds enfants d'avoir une couleur de lien "
+"différente des nœuds parents."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:95
+msgid ""
+"Added ability to cause a descendant node with a different color than its "
+"parent to re-use the parent color."
+msgstr ""
+"Ajout de la possibilité de créer un nœud enfant avec une couleur diffénte de "
+"son parent pour réutiliser la couleur du parent."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:96
+#, fuzzy
+msgid "Added ability to select children nodes using Control-click."
+msgstr ""
+"Ajout de la possibilité de sélectionner les nœuds enfants en utilisant "
+"Control-Click."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:97
+msgid ""
+"Added ability to export a mind-map as a new <em>Portable Minder</em> "
+"filetype which will allow Minder files to be copied between different users/"
+"filesystems."
+msgstr ""
+"Ajout de la possibilité d'exporter une carte mentale au nouveau format de "
+"fichier <em>Minder portable</em> qui permet de partager des fichiers Minder "
+"avec d'autres utilisateurs/systèmes de fichiers."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:98
+#, fuzzy
+msgid "Added ability to export to Org-Mode format."
+msgstr "Ajout de la possibilité d'exporter au format Org-Mode."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:100
+#: data/com.github.phase1geo.minder.appdata.xml.in:143
+#: data/com.github.phase1geo.minder.appdata.xml.in:158
+#: data/com.github.phase1geo.minder.appdata.xml.in:179
+#: data/com.github.phase1geo.minder.appdata.xml.in:219
+msgid "Changes"
+msgstr "Modifications"
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:102
+msgid "Updated French translation (thanks to Nathan Bonnemains)."
+msgstr "Ajout des traductions en français (grâce à Nathan Bonnemains)."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:103
+msgid "Improved OPML import support."
+msgstr "Amélioration de l'import de fichiers OPML."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:104
+msgid "Changed ability to select a subtree by Control + double-click."
+msgstr ""
+"Modification de la sélection des sous-arbres avec Control + Double clic."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:105
+msgid ""
+"Changed ability to select all nodes of the current level by Control + triple-"
+"click."
+msgstr ""
+"Modification de la sélection de tous les nœuds du niveau courant avec "
+"Control + Triple clic."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:107
+#: data/com.github.phase1geo.minder.appdata.xml.in:150
+#: data/com.github.phase1geo.minder.appdata.xml.in:162
+#: data/com.github.phase1geo.minder.appdata.xml.in:187
+#: data/com.github.phase1geo.minder.appdata.xml.in:230
+msgid "Bug Fixes"
+msgstr "Corrections de bugs"
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:109
+msgid "Fixed NodeJS version for Travis CI."
+msgstr "Correction de la version de NodeJS dans Travis CI."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:110
+msgid ""
+"Fixed issue with adding a new child node that doesn't cause other descendant "
+"nodes to unfold."
+msgstr ""
+"Correction du problème lors de l'ajout d'un nœud enfant qui empêchait les "
+"autres nœuds enfants d'être dépliés."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:111
+msgid "Fixed issue with showing/hiding sidebar."
+msgstr ""
+"Correction d'un problème avec l'action d'afficher/masquer la barre latérale."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:112
+msgid "Fixed segmentation faults when loading a theme."
+msgstr "Correction d'une erreur de segmentation lors du chargement d'un thème."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:113
+msgid ""
+"Fixed issue with the style inspector <em>Change Affect</em> value when "
+"selection changes (thanks to Viliam K.)."
+msgstr ""
+"Correction d'un problème avec l'inspecteur de style lorsque la valeur du "
+"sélécteur <em>Les modifications affectent</em> change (grâce à Vilian K.)."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:114
+msgid "Fixed issue with node markup within the node text (thanks to Viliam K)."
+msgstr ""
+"Correction d'un problème avec le style de nœud dans le texte (grâce à Viliam "
+"K.)."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:115
+msgid ""
+"Fixed issue with tab state not being properly saved when a new tab is added."
+msgstr ""
+"Correction d'un problème avec l'état des onglets qui n'étaient pas "
+"correctement enregistré lors de l'ajout d'un nouvel onglet."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:116
+msgid ""
+"Fixed bug with updating tab tooltip and saving tab state when filename is "
+"changed."
+msgstr ""
+"Correction d'un bug lors de la mise à jour de l'infobulle de l'onglet et "
+"l'enregistrement de l'état de l'onglet lorsque le nom de fichier est "
+"différent."
+
+#: data/com.github.phase1geo.minder.appdata.xml.in:124
 msgid ""
 "Added ability to delete a single node (instead of the node and its subtree) "
 "in the contextual menu."
@@ -151,7 +327,7 @@ msgstr ""
 "Ajout de la possibilité de supprimer un nœud seul (au lieu du nœud et de ses "
 "enfants) dans le menu contextuel."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:91
+#: data/com.github.phase1geo.minder.appdata.xml.in:125
 msgid ""
 "When a new document is first saved, the first root node text is used as the "
 "default filename."
@@ -159,46 +335,39 @@ msgstr ""
 "Lorsqu'un document est enregistré pour la première fois, le nom du premier "
 "nœud racine est utilisé comme nom de fichier par défaut."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:94
+#: data/com.github.phase1geo.minder.appdata.xml.in:128
 msgid "Changing styles"
 msgstr "Modification des styles"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:95
+#: data/com.github.phase1geo.minder.appdata.xml.in:129
 msgid "Copy, cut, paste and delete support"
 msgstr "Prise en charge des fonctions copier, couper, coller et supprimer"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:96
+#: data/com.github.phase1geo.minder.appdata.xml.in:130
 msgid "Connect two selected nodes"
 msgstr "Connectez deux nœuds sélectionnés"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:97
+#: data/com.github.phase1geo.minder.appdata.xml.in:131
 msgid "Create node links between two or more selected nodes"
 msgstr "Créez des liens entre deux nœuds sélectionnés ou plus"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:98
+#: data/com.github.phase1geo.minder.appdata.xml.in:132
 msgid "Fold/unfold selected nodes"
 msgstr "Pliez/Dépliez les nœuds sélectionnés"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:101
+#: data/com.github.phase1geo.minder.appdata.xml.in:135
 msgid "Added support for URLs in node titles."
 msgstr "Ajout de la prise en charge des URL dans le titre des nœuds."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:104
+#: data/com.github.phase1geo.minder.appdata.xml.in:138
 msgid "Notes are syntax highlighted"
 msgstr "La correction orthographique fonctionne dans les notes"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:105
+#: data/com.github.phase1geo.minder.appdata.xml.in:139
 msgid "Embedded URLs can be opened by Control-Clicking on them"
 msgstr "Les URL peuvent être ouvertes en effectuant Ctrl + Clic dessus"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:109
-#: data/com.github.phase1geo.minder.appdata.xml.in:124
 #: data/com.github.phase1geo.minder.appdata.xml.in:145
-#: data/com.github.phase1geo.minder.appdata.xml.in:185
-msgid "Changes"
-msgstr "Modifications"
-
-#: data/com.github.phase1geo.minder.appdata.xml.in:111
 msgid ""
 "Updated application icon and other recently improved icons for improved "
 "readability (thanks to Nararyans R.I.)."
@@ -206,29 +375,22 @@ msgstr ""
 "Mise à jour de l'icône de l'application et des autres icônes pour plus de "
 "lisibilité (grâce à Nararyans R.I.)."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:112
+#: data/com.github.phase1geo.minder.appdata.xml.in:146
 msgid "Improved look and readability of theme icons in the sidebar."
 msgstr ""
 "Meilleure apparence et lisibilité des icônes de thème dans la barre latérale."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:113
+#: data/com.github.phase1geo.minder.appdata.xml.in:147
 msgid "Changed sidebar to display theme icons in a grid layout."
 msgstr ""
 "Modification de la barre latérale pour afficher les icônes de thème dans une "
 "grille."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:114
+#: data/com.github.phase1geo.minder.appdata.xml.in:148
 msgid "Improved various export format output."
 msgstr "Amélioration des différents formats d'exportation."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:116
-#: data/com.github.phase1geo.minder.appdata.xml.in:128
-#: data/com.github.phase1geo.minder.appdata.xml.in:153
-#: data/com.github.phase1geo.minder.appdata.xml.in:196
-msgid "Bug Fixes"
-msgstr "Corrections de bugs"
-
-#: data/com.github.phase1geo.minder.appdata.xml.in:118
+#: data/com.github.phase1geo.minder.appdata.xml.in:152
 msgid ""
 "Fixed various compiler warnings/errors after compiling with latest version "
 "of Vala compiler."
@@ -236,31 +398,31 @@ msgstr ""
 "Correction de divers avertissements/erreurs après compilation avec la "
 "dernière version du compilateur Vala."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:126
+#: data/com.github.phase1geo.minder.appdata.xml.in:160
 msgid "Improved various icons (thanks to Nararyans R.I.)"
 msgstr "Amélioration de diverses icônes (grâce à Nararyans R.I.)"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:130
+#: data/com.github.phase1geo.minder.appdata.xml.in:164
 msgid "Downgraded Node.js to fix Travis CI builds"
 msgstr ""
 "Rétrogradation de Node.js pour corriger les problèmes d'intégration continue "
 "avec Travis CI"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:131
+#: data/com.github.phase1geo.minder.appdata.xml.in:165
 msgid "Fixed various compiler errors/warnings"
 msgstr "Correction de diverses erreurs/avertissements lors de la compilation"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:139
+#: data/com.github.phase1geo.minder.appdata.xml.in:173
 msgid "Added export to yEd."
 msgstr "Ajout de l'exportation au format yEd."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:140
+#: data/com.github.phase1geo.minder.appdata.xml.in:174
 msgid "Added ability to create, edit and delete custom themes."
 msgstr ""
 "Ajout de la possibilité de créer, modifier et supprimer des thèmes "
 "personnalisés"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:141
+#: data/com.github.phase1geo.minder.appdata.xml.in:175
 msgid ""
 "Added new quick entry mode, allowing node trees to be input within a text "
 "editor."
@@ -268,17 +430,17 @@ msgstr ""
 "Ajout d'un nouveau mode d'entrée rapide, permettant aux arbres de nœuds "
 "d'être saisis depuis l'éditeur de texte."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:142
+#: data/com.github.phase1geo.minder.appdata.xml.in:176
 msgid "Added Control-W keyboard shortcut to close the current tab."
 msgstr "Ajout du raccourci clavier Ctrl + W pour fermer l'onglet actif."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:143
+#: data/com.github.phase1geo.minder.appdata.xml.in:177
 msgid "Added shortcut exploration help window (use F1 key to display)."
 msgstr ""
 "Ajouter du raccourci pour parcourir la fenêtre d'aide (utilisez la touche F1 "
 "pour l'afficher)."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:147
+#: data/com.github.phase1geo.minder.appdata.xml.in:181
 msgid ""
 "New search icon which has better contrast for Minder's themed header bar "
 "(thanks to Nararyans R.I.)."
@@ -286,13 +448,13 @@ msgstr ""
 "Nouvelle icône de recherche avec un meilleur contraste pour le thème de "
 "l'entête de Minder(grâce à Nararyans R.I.)."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:148
+#: data/com.github.phase1geo.minder.appdata.xml.in:182
 msgid "New non-symbolic sidebar icon in header bar (thanks to Nararyans R.I.)."
 msgstr ""
 "Nouvelle icône non symbolique pour la barre latérale dans l'entête (grâce à "
 "Nararyans R.I.)."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:149
+#: data/com.github.phase1geo.minder.appdata.xml.in:183
 msgid ""
 "New Minder application icon which fits in with the elementary OS color "
 "scheme better (thansk to Nararyans R.I.)."
@@ -300,29 +462,29 @@ msgstr ""
 "Nouvelle icône de l'application Minder qui correspond mieux au schéma de "
 "couleurs d'elementary OS (grâce à Nararyans R.I.)."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:150
+#: data/com.github.phase1geo.minder.appdata.xml.in:184
 msgid "New focus icon in header bar (thanks to Nararyans R.I.)."
 msgstr ""
 "Nouvelle icône de mode concentration dans l'entête (grâce à Nararyans R.I.)."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:151
+#: data/com.github.phase1geo.minder.appdata.xml.in:185
 msgid "Improved styling when creating a new node/connection."
 msgstr "Amélioration du style lors de la création d'un nouveau nœud/connexion."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:155
+#: data/com.github.phase1geo.minder.appdata.xml.in:189
 msgid ""
 "Fixed issue where separate trees in same mind-map where allowed to overlap."
 msgstr ""
 "Correction d'un problème ou les arbres séparés dans la même carte mentale "
 "pouvaient déborder."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:156
+#: data/com.github.phase1geo.minder.appdata.xml.in:190
 msgid "Fixed node link drawing issue when using manual layout mode."
 msgstr ""
 "Correction d'un problème de dessin des liens de nœud lors de l'utilisation "
 "du mode de disposition manuelle."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:157
+#: data/com.github.phase1geo.minder.appdata.xml.in:191
 msgid ""
 "Fixed issues drawing arrows properly when straight node links were being "
 "used."
@@ -330,44 +492,44 @@ msgstr ""
 "Correction de problèmes de dessin correct des flèches lors de l'utilisation "
 "de liens de nœuds droits."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:158
+#: data/com.github.phase1geo.minder.appdata.xml.in:192
 msgid "Fixed display issues with the node fill switch in the style inspector."
 msgstr ""
 "Correction de problèmes d'affichage avec le bouton de remplissage de nœud "
 "dans l'inspecteur de style."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:159
+#: data/com.github.phase1geo.minder.appdata.xml.in:193
 msgid "Fixed support for cut, copy and pasting connection title text."
 msgstr ""
 "Correction de la prise en charge des fonctions couper, copier et coller du "
 "titre des connexions."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:160
+#: data/com.github.phase1geo.minder.appdata.xml.in:194
 msgid "Fixed keyboard shortcut for toggling focus mode."
 msgstr ""
 "Correction du raccourci clavier pour activer/désactiver le mode "
 "concentration."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:167
+#: data/com.github.phase1geo.minder.appdata.xml.in:201
 msgid "Fixed issue with automatic layout that was introduced in 1.4.0."
 msgstr ""
 "Correction d'un problème avec la disposition automatique introduite en 1.4.0."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:175
+#: data/com.github.phase1geo.minder.appdata.xml.in:209
 msgid "Added support for focus mode."
 msgstr "Ajout de la prise en charge du mode concentration."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:176
+#: data/com.github.phase1geo.minder.appdata.xml.in:210
 msgid "Added support for multiple documents with tabs."
 msgstr "Ajout de la prise en charge de documents multiples avec onglets."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:177
+#: data/com.github.phase1geo.minder.appdata.xml.in:211
 msgid "Added support for resizing the inspector sidebar."
 msgstr ""
 "Ajout de la prise en charge du redimensionnement de la barre latérale de "
 "l'inspecteur."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:178
+#: data/com.github.phase1geo.minder.appdata.xml.in:212
 msgid ""
 "Added support for creating a new node directly from editing an existing node "
 "presssing Return or Tab."
@@ -375,26 +537,26 @@ msgstr ""
 "Ajout de la prise en charge pour la création d'un nouveau nœud directement à "
 "partir de l'édition d'un nœud existant en appuyant sur Entrée ou Tab."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:179
+#: data/com.github.phase1geo.minder.appdata.xml.in:213
 msgid "Added support for adding a new parent node to an existing node."
 msgstr ""
 "Ajout de la prise en charge pour ajouter un nouveau nœud parent à un nœud "
 "existant."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:180
+#: data/com.github.phase1geo.minder.appdata.xml.in:214
 msgid ""
 "Added support for importing/exporting to FreeMind and Freeplane formats."
 msgstr ""
 "Ajout de la prise en charge de l'importation/exportation aux formats "
 "FreeMind et Freeplane."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:181
+#: data/com.github.phase1geo.minder.appdata.xml.in:215
 msgid "Added support for sorting children either alphabetically or randomly."
 msgstr ""
 "Ajout de la prise en charge du tri des enfants alphabétiquement ou "
 "aléatoirement."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:182
+#: data/com.github.phase1geo.minder.appdata.xml.in:216
 msgid ""
 "Added support for creating a link from one node to another node in the same "
 "map."
@@ -402,26 +564,26 @@ msgstr ""
 "Ajout de la prise en charge pour la création d'un lien d'un nœud à un autre "
 "dans la même carte."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:183
+#: data/com.github.phase1geo.minder.appdata.xml.in:217
 msgid "Added support for building a Flatpak."
 msgstr "Ajout de la prise en charge pour Flatpak."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:187
+#: data/com.github.phase1geo.minder.appdata.xml.in:221
 msgid "Removed markup from translated strings."
 msgstr "Suppression des balises des chaînes de caractères traduites."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:188
+#: data/com.github.phase1geo.minder.appdata.xml.in:222
 msgid "Standardized tooltips that display accelerator information."
 msgstr ""
 "Indications standard pour afficher les informations des raccourcis clavier."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:189
+#: data/com.github.phase1geo.minder.appdata.xml.in:223
 msgid "Changed the way that node/connection titles are displayed in inspector."
 msgstr ""
 "Modification de la façon dont les titres de nœud/connexion sont affichés "
 "dans l'inspecteur."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:190
+#: data/com.github.phase1geo.minder.appdata.xml.in:224
 msgid ""
 "Changed app terminal script to allow command-line arguments to be passed to "
 "debug subcommand."
@@ -429,20 +591,20 @@ msgstr ""
 "Modification du script du terminal de l'application pour autoriser les "
 "arguments en ligne de commande a être passés en sous-commandes de débogage."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:191
+#: data/com.github.phase1geo.minder.appdata.xml.in:225
 msgid "Changed header bar and widget colors to match Minder brand color."
 msgstr ""
 "Modification des couleurs de la barre d'en-tête et des widgets pour "
 "correspondre à la couleur symbolique de Minder."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:192
+#: data/com.github.phase1geo.minder.appdata.xml.in:226
 msgid ""
 "Changed search icon in header bar to a symbolic icon to improve readability."
 msgstr ""
 "Modification de l'icône de recherche dans la barre d'en-tête en icône "
 "symbolique pour améliorer la lisibilité."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:193
+#: data/com.github.phase1geo.minder.appdata.xml.in:227
 msgid ""
 "When note tooltip is displayed, markup text is rendered for improved "
 "readability."
@@ -450,7 +612,7 @@ msgstr ""
 "Lorsque l'indicateur des notes est affiché, le marquage du texte est "
 "restitué pour une meilleure lisibilité."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:194
+#: data/com.github.phase1geo.minder.appdata.xml.in:228
 msgid ""
 "Enhanced app script to allow command-line arguments to be passed to debug "
 "subcommand."
@@ -458,7 +620,7 @@ msgstr ""
 "Amélioration du script de l'application pour autoriser les arguments en "
 "ligne de commande à être passés en sous-commandes de débogage."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:198
+#: data/com.github.phase1geo.minder.appdata.xml.in:232
 msgid ""
 "Fixed an issue with calculating connection endpoints when a portion of the "
 "node is not visible."
@@ -466,40 +628,40 @@ msgstr ""
 "Correction d'un problème avec le calcul des point de fin de connexion "
 "lorsqu'un bout du nœud n'est pas visible."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:199
+#: data/com.github.phase1geo.minder.appdata.xml.in:233
 msgid "Fixed file naming issue when a file is imported."
 msgstr ""
 "Correction des problèmes de nommage du fichier lors de l'importation d'un "
 "fichier."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:200
+#: data/com.github.phase1geo.minder.appdata.xml.in:234
 msgid ""
 "Fixed issue with displaying resized nodes on open or application startup."
 msgstr ""
 "Correction d'un problème lors de l'affichage des nœuds redimensionnés à "
 "l'ouverture ou au démarrage de l'application."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:207
+#: data/com.github.phase1geo.minder.appdata.xml.in:241
 msgid "Fixing issue with export functions."
 msgstr "Correction des problèmes avec les fonctions d'export."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:213
+#: data/com.github.phase1geo.minder.appdata.xml.in:247
 msgid "Let's stay connected!"
 msgstr "Restons connectés !"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:215
+#: data/com.github.phase1geo.minder.appdata.xml.in:249
 msgid "Added support for creating a visual connection between any two nodes."
 msgstr ""
 "Ajout de la prise en charge de la création d'une connexion visuelle entre "
 "deux nœuds quelconques."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:216
+#: data/com.github.phase1geo.minder.appdata.xml.in:250
 msgid "Added ability to show/hide all connections in the map."
 msgstr ""
 "Ajout de la possibilité d'afficher/masquer toutes les connexions dans la "
 "carte."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:217
+#: data/com.github.phase1geo.minder.appdata.xml.in:251
 msgid ""
 "Added support for remembering the last selected child of a node when "
 "navigating the map with the keyboard."
@@ -507,7 +669,7 @@ msgstr ""
 "Ajout de la prise en charge de la mémorisation du dernier enfant sélectionné "
 "d'un nœud lors de la navigation sur la carte à l'aide du clavier."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:218
+#: data/com.github.phase1geo.minder.appdata.xml.in:252
 msgid ""
 "When escape key is used when editing text, editing mode is ended without "
 "reverting text."
@@ -515,7 +677,7 @@ msgstr ""
 "Lorsque la touche d'échappement est utilisée lors de l'édition de texte, le "
 "mode d'édition est interrompu sans que le texte ne soit réinitialisé."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:219
+#: data/com.github.phase1geo.minder.appdata.xml.in:253
 msgid ""
 "Created unique contextual menus depending on what is selected in the mind "
 "map."
@@ -523,7 +685,7 @@ msgstr ""
 "Création de menus contextuels uniques en fonction de ce qui est sélectionné "
 "dans la carte mentale."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:220
+#: data/com.github.phase1geo.minder.appdata.xml.in:254
 msgid ""
 "Changed Node sidebar tab to Current which shows either the currently "
 "selected node or connection."
@@ -531,17 +693,17 @@ msgstr ""
 "Changement de l'onglet Nœud de la barre latérale à Courant qui affiche soit "
 "le nœud ou la connexion actuellement sélectionné(e)."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:221
+#: data/com.github.phase1geo.minder.appdata.xml.in:255
 msgid "Improved link drawing when a node tree is being moved."
 msgstr ""
 "Amélioration du dessin des liens lorsqu'une arborescence de nœuds est "
 "déplacée."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:222
+#: data/com.github.phase1geo.minder.appdata.xml.in:256
 msgid "Switched from using GtkFileChooserDialog to GtkFileChooserNative."
 msgstr "Passage de GtkFileChooserDialog à GtkFileChooserNative."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:223
+#: data/com.github.phase1geo.minder.appdata.xml.in:257
 msgid ""
 "Added support for inserting emoji when editing text in the mind map (use "
 "Control-period)."
@@ -549,18 +711,18 @@ msgstr ""
 "Ajout du support pour l'insertion d'emojis lors de l'édition de texte dans "
 "la carte mentale (utilisez la combinaison CTRL + .)."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:224
+#: data/com.github.phase1geo.minder.appdata.xml.in:258
 msgid "Improved readability of theme name when the theme is selected."
 msgstr "Meilleure lisibilité du nom du thème lorsque le thème est sélectionné."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:225
+#: data/com.github.phase1geo.minder.appdata.xml.in:259
 msgid ""
 "Fixed issue where changing a global style was not saved/applied to new nodes."
 msgstr ""
 "Correction d'un problème où le changement d'un style global n'était pas "
 "sauvegardé/appliqué aux nouveaux nœuds."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:226
+#: data/com.github.phase1geo.minder.appdata.xml.in:260
 msgid ""
 "Improved copy/paste support of nodes so that copied items can be pasted in "
 "other mind maps."
@@ -568,7 +730,7 @@ msgstr ""
 "Amélioration du copier/coller des nœuds pour que les éléments copiés "
 "puissent être collés dans d'autres cartes mentales."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:227
+#: data/com.github.phase1geo.minder.appdata.xml.in:261
 msgid ""
 "Added support for dynamically changing to dark mode in the UI if the prefer-"
 "dark desktop gsetting is set."
@@ -576,32 +738,32 @@ msgstr ""
 "Ajout de la prise en charge du passage dynamique en thème sombre dans "
 "l'interface utilisateur si l'option de thème sombre est activée."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:228
+#: data/com.github.phase1geo.minder.appdata.xml.in:262
 msgid "Added ability to show/hide each panel within the style inspector."
 msgstr ""
 "Ajout de la possibilité d'afficher/masquer chaque panneau dans l'inspecteur "
 "de style."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:229
+#: data/com.github.phase1geo.minder.appdata.xml.in:263
 msgid "Removed support for Loki builds."
 msgstr "Arrêt de la prise en charge pour Loki."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:236
+#: data/com.github.phase1geo.minder.appdata.xml.in:270
 msgid "Fixing appdata.xml file omission."
 msgstr "Correction d'une omission dans le fichier appdata.xml."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:237
+#: data/com.github.phase1geo.minder.appdata.xml.in:271
 msgid ""
 "Removing automatic style apply when the affects is set to certain values."
 msgstr ""
 "La suppression du style automatique s'applique lorsque l'effet est réglé sur "
 "certaines valeurs."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:244
+#: data/com.github.phase1geo.minder.appdata.xml.in:278
 msgid "Added Spanish translation."
 msgstr "Ajout des traductions en espagnol."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:245
+#: data/com.github.phase1geo.minder.appdata.xml.in:279
 msgid ""
 "Added support for Control-Return/Tab to support adding newlines/tabs in a "
 "node's title."
@@ -609,23 +771,23 @@ msgstr ""
 "Ajout de la prise en charge du raccourci CTRL + Entrée/TAB pour ajouter des "
 "nouvelles lignes/tabulations dans le titre d'un nœud."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:246
+#: data/com.github.phase1geo.minder.appdata.xml.in:280
 msgid "Improved node title editing support for selection and cursor movement."
 msgstr ""
 "Amélioration de la prise en charge de l'édition du titre des nœuds pour la "
 "sélection et le déplacement du curseur."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:247
+#: data/com.github.phase1geo.minder.appdata.xml.in:281
 msgid "Added support for automatically opening Minder files from Files."
 msgstr ""
 "Ajout de la prise en charge de l'ouverture automatique des fichiers Minder à "
 "partir de Fichiers."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:248
+#: data/com.github.phase1geo.minder.appdata.xml.in:282
 msgid "Added ability to modify styles of nodes and links."
 msgstr "Ajout de la possibilité de modifier les styles des nœuds et des liens."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:249
+#: data/com.github.phase1geo.minder.appdata.xml.in:283
 msgid ""
 "Changed layouts to be stored on a per tree basis instead of a per document "
 "basis."
@@ -633,49 +795,49 @@ msgstr ""
 "Modification de la disposition pour l'enregistrement par arbre au lieu de "
 "l'enregistrement par document."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:250
+#: data/com.github.phase1geo.minder.appdata.xml.in:284
 msgid "Added support for exporting to the Mermaid format."
 msgstr "Ajout de la prise en charge de l'exportation au format Mermaid."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:251
+#: data/com.github.phase1geo.minder.appdata.xml.in:285
 msgid "Added support for disabling/enabling displaying markup in node title."
 msgstr ""
 "Ajout de la prise en charge de la désactivation/activation de l'affichage du "
 "balisage dans le titre du nœud."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:252
+#: data/com.github.phase1geo.minder.appdata.xml.in:286
 msgid "Improved the look of the fold indicators."
 msgstr "Amélioration de l'apparence des indicateurs de pli."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:253
+#: data/com.github.phase1geo.minder.appdata.xml.in:287
 msgid "Lots of bug fixes."
 msgstr "Nombreuses corrections de bugs."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:260
+#: data/com.github.phase1geo.minder.appdata.xml.in:294
 msgid "Adding Spanish translation (thanks to Adolfo Jayme-Barrientos)."
 msgstr "Ajout des traductions en espagnol (grâce à Adolfo Jayme-Barrientos)."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:261
+#: data/com.github.phase1geo.minder.appdata.xml.in:295
 msgid "Adding support for special character insertion via the Compose key."
 msgstr ""
 "Ajout du support pour l'insertion de caractères spéciaux avec la touche "
 "Compose."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:267
+#: data/com.github.phase1geo.minder.appdata.xml.in:301
 msgid "Updating French translation."
 msgstr "Mises à jour des traductions en français."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:272
+#: data/com.github.phase1geo.minder.appdata.xml.in:306
 msgid "Bug fix release"
 msgstr "Version corrective"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:274
+#: data/com.github.phase1geo.minder.appdata.xml.in:308
 msgid "Fixed bugs related to editing unicode characters in map area."
 msgstr ""
 "Correction de bugs liés à l'édition de caractères unicode dans la zone de la "
 "carte."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:275
+#: data/com.github.phase1geo.minder.appdata.xml.in:309
 msgid ""
 "Reduced height of node textbox in sidebar to help alleviate window sizing "
 "problems."
@@ -683,88 +845,88 @@ msgstr ""
 "Réduction de la hauteur de la zone de texte du nœud dans la barre latérale "
 "pour aider à diminuer les problèmes de dimensionnement de la fenêtre."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:276
+#: data/com.github.phase1geo.minder.appdata.xml.in:310
 msgid ""
 "Fixed issue with moving a node to a different position within a parent node."
 msgstr ""
 "Correction d'un problème avec le déplacement d'un nœud vers une position "
 "différente au sein d'un nœud parent."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:277
+#: data/com.github.phase1geo.minder.appdata.xml.in:311
 msgid "Fixed issue connecting a root node to another node."
 msgstr ""
 "Correction d'un problème de connexion d'un nœud racine à un autre nœud."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:283
+#: data/com.github.phase1geo.minder.appdata.xml.in:317
 msgid "Images now supported!"
 msgstr "Les images sont désormais prises en charge !"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:285
+#: data/com.github.phase1geo.minder.appdata.xml.in:319
 msgid "Added support for images within nodes."
 msgstr "Ajout de la prise en charge des images à l'intérieur des nœuds."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:286
+#: data/com.github.phase1geo.minder.appdata.xml.in:320
 msgid "Added basic image editing support."
 msgstr "Ajout de la prise en charge mimimale de la modification d'image."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:287
+#: data/com.github.phase1geo.minder.appdata.xml.in:321
 msgid "Added support for dragging and dropping local and web images."
 msgstr ""
 "Ajout de la prise en charge du glisser-déposer d'images locales ou web."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:288
+#: data/com.github.phase1geo.minder.appdata.xml.in:322
 msgid "Added support for resizing node width."
 msgstr ""
 "Ajout de la prise en charge du redimensionnement de la largeur des nœuds."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:289
+#: data/com.github.phase1geo.minder.appdata.xml.in:323
 msgid "Changed cursors when over a task button."
 msgstr "Modification du curseur au survol d'un bouton de tâche."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:290
+#: data/com.github.phase1geo.minder.appdata.xml.in:324
 msgid "Changed location of task and note elements in a node."
 msgstr ""
 "Modification de l'emplacement des éléments de tâche et de note dans un nœud."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:291
+#: data/com.github.phase1geo.minder.appdata.xml.in:325
 msgid "Added support for keeping the map from scrolling off screen."
 msgstr ""
 "Ajout de la prise en charge du maintien du défilement de la carte de l'écran."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:292
+#: data/com.github.phase1geo.minder.appdata.xml.in:326
 msgid "Added support for shift-mousewheel to scroll horizontally."
 msgstr ""
 "Ajout de la prise en charge de la molette de la souris avec shift pour le "
 "défilement horizontal."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:293
+#: data/com.github.phase1geo.minder.appdata.xml.in:327
 msgid "Added support for control-mousewheel to zoom in/out."
 msgstr ""
 "Ajout de la prise en charge de la molette de la souris pour effectuer un "
 "zoom avant/arrière."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:294
+#: data/com.github.phase1geo.minder.appdata.xml.in:328
 msgid "Fixed issue with drawing background when zoom factor was small."
 msgstr ""
 "Correction d'un problème avec l'arrière-plan du graphique lorsque le facteur "
 "de zoom était faible."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:295
+#: data/com.github.phase1geo.minder.appdata.xml.in:329
 msgid ""
 "Custom icons are now stored as a gresource rather than in the file system."
 msgstr ""
 "Les icônes personnalisées sont maintenant stockées en tant que ressource "
 "gresource plutôt que dans le système de fichiers."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:296
+#: data/com.github.phase1geo.minder.appdata.xml.in:330
 msgid "Other minor bug fixes."
 msgstr "Autres corrections de bugs mineures."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:302
+#: data/com.github.phase1geo.minder.appdata.xml.in:336
 msgid "Support for more export types and bug fixes."
 msgstr "Prise en charge de plus de types d'exportation et corrections de bugs."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:304
+#: data/com.github.phase1geo.minder.appdata.xml.in:338
 msgid ""
 "Added support for exporting to SVG, JPEG, BMP, Markdown, PlainText and CSV "
 "formats."
@@ -772,32 +934,32 @@ msgstr ""
 "Ajout de la prise en charge pour l'exportation vers les formats SVG, JPEG, "
 "BMP, Mardown, Texte brut et CSV."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:305
+#: data/com.github.phase1geo.minder.appdata.xml.in:339
 msgid "Added support for folding all completed tasks in map inspector."
 msgstr ""
 "Ajout de la prise en charge pour plier toutes les tâches complétées dans "
 "l'inspecteur de carte."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:306
+#: data/com.github.phase1geo.minder.appdata.xml.in:340
 msgid "Added support for unfolding all folded nodes in map inspector."
 msgstr ""
 "Ajout de la prise en charge pour déplier tous les nœuds pliés dans "
 "l'inspecteur de carte."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:307
+#: data/com.github.phase1geo.minder.appdata.xml.in:341
 msgid "Added Solarized Dark and Solarized Light themes."
 msgstr "AJout des thèmes Solarized Dark et Solarized Light."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:308
+#: data/com.github.phase1geo.minder.appdata.xml.in:342
 msgid "Changing button display in map inspector."
 msgstr "Modification de l'affichage du bouton dans l'inspecteur de carte."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:309
+#: data/com.github.phase1geo.minder.appdata.xml.in:343
 msgid "Cleaning up Export menu to include a single \"Export…\" option."
 msgstr ""
 "Nettoyage du menu Exporter pour inclure une seule option « Exporter… »."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:310
+#: data/com.github.phase1geo.minder.appdata.xml.in:344
 msgid ""
 "Fixing issue where modified node title in node inspector was lost when input "
 "focus was changed."
@@ -805,87 +967,78 @@ msgstr ""
 "Correction d'un problème où le titre de nœud modifié dans l'inspecteur de "
 "nœud était perdu lorsque le point focalisé en entrée était modifié."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:311
+#: data/com.github.phase1geo.minder.appdata.xml.in:345
 msgid "Fixing issue where an entire tree is attached to another tree."
 msgstr ""
 "Correction d'un problème où un arbre entier est attaché à un autre arbre."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:312
+#: data/com.github.phase1geo.minder.appdata.xml.in:346
 msgid "Added Czech translation (thanks to Jan Marek!)."
 msgstr "Ajout des traductions en tchèque (grâce à Jan Marek !)."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:313
+#: data/com.github.phase1geo.minder.appdata.xml.in:347
 msgid "Added French translation (thanks to Yannick A.!)."
 msgstr "Ajout des traductions en français (grâce à Yannick A. !)."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:314
+#: data/com.github.phase1geo.minder.appdata.xml.in:348
 msgid "Added Brazilian Portuguese translation (thanks to btd1337!)"
 msgstr "Ajout des traductions en portugais brésilien (grâce à btd1337 !)"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:320
+#: data/com.github.phase1geo.minder.appdata.xml.in:354
 msgid "Initial startup bug fix."
 msgstr "Correction de bug au premier démarrage."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:325
+#: data/com.github.phase1geo.minder.appdata.xml.in:359
 msgid "Search improvements and bug fixes"
 msgstr "Amélioration de la recherche et corrections de bugs"
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:327
+#: data/com.github.phase1geo.minder.appdata.xml.in:361
 msgid "Added ability to search within notes."
 msgstr "Ajout de la possibilité de chercher parmi les notes."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:328
+#: data/com.github.phase1geo.minder.appdata.xml.in:362
 msgid ""
 "Added ability to optionally control search criteria within search popover."
 msgstr ""
 "Ajout de la possibilité pour optionnellement contrôler les critères de "
 "recherche dans le volet de recherche."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:329
+#: data/com.github.phase1geo.minder.appdata.xml.in:363
 msgid "Fixed screenshots."
 msgstr "Correction des captures d'écran."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:330
+#: data/com.github.phase1geo.minder.appdata.xml.in:364
 msgid ""
 "Changed properties header bar icon to a sidebar hide/show icon for clarity."
 msgstr ""
 "L'icône de la barre supérieure des propriétés a été changée en icône de "
 "masquage/affichage dans la barre latérale pour plus de clarté."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:331
+#: data/com.github.phase1geo.minder.appdata.xml.in:365
 msgid "Several minor UI improvements."
 msgstr "Améliorations mineures diverses de l'interface."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:332
+#: data/com.github.phase1geo.minder.appdata.xml.in:366
 msgid "Removing deprecated GTK calls."
 msgstr "Suprresion des éléments GTK dépréciés."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:333
+#: data/com.github.phase1geo.minder.appdata.xml.in:367
 msgid "Added ability to double-click on a node to make it editable."
 msgstr ""
 "Ajout de la possibilité de double-cliquer sur un nœud pour le rendre "
 "éditable."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:334
+#: data/com.github.phase1geo.minder.appdata.xml.in:368
 msgid "Bug fixes."
 msgstr "Corrections de bugs."
 
-#: data/com.github.phase1geo.minder.appdata.xml.in:340
+#: data/com.github.phase1geo.minder.appdata.xml.in:374
 msgid "Initial release"
 msgstr "Version initiale"
 
-#: data/com.github.phase1geo.minder.desktop.in:4
-msgid "Mind-mapper"
-msgstr "Créateur de cartes mentales"
-
-#: data/com.github.phase1geo.minder.desktop.in:8
-msgid "com.github.phase1geo.minder"
-msgstr "com.github.phase1geo.minder"
-
-#: data/com.github.phase1geo.minder.desktop.in:14
-msgid "Mind;Mapping;"
-msgstr "Mentale;Carte;"
-
-#: data/com.github.phase1geo.minder.desktop.in:18
-msgid "New Document"
-msgstr "Nouveau document"
+#~ msgid ""
+#~ "Export to PDF, PNG, JPEG, BMP, SVG, OPML, CSV, Markdown, PlainText, "
+#~ "FreeMind, Freeplane, yEd and Mermaid formats."
+#~ msgstr ""
+#~ "Exportez aux formats PDF, PNG, JPEG, BMP, SVG, OPML, CSV, Markdown, Texte "
+#~ "brut, FreeMind, Freeplane, yEd et Mermaid."

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.phase1geo.minder\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-15 04:19-0500\n"
+"POT-Creation-Date: 2020-04-15 19:18+0200\n"
 "PO-Revision-Date: 2019-03-24 15:24+0100\n"
 "Last-Translator: Nathan Bonnemains (@NathanBnm)\n"
 "Language-Team: Français\n"
@@ -236,6 +236,10 @@ msgstr "plier les tâches terminées"
 #: src/DrawArea.vala:2582
 msgid "unfold all tasks"
 msgstr "déplier toutes les tâches"
+
+#: src/Document.vala:65
+msgid "unnamed"
+msgstr "sans nom"
 
 #: src/ImageEditor.vala:179
 #, c-format


### PR DESCRIPTION
I updated "unnamed" (I had to add `Document.vala` to translations)

I also updated extra translations. I just removed an extra "SVG" from app description and corrected a change log about Travis CI.

I moved the `desktop` file first in `extra/POTFILES` because translators won't translate it it's at the end of the file and if they don't translate the changelog. It's quite important so it's better to put it first.