### PR TITLE
get valac name and path correctly from the build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -40,8 +40,7 @@ if gtk_dep.version().version_compare('>=3.22.0')
 endif
 
 # If the valac version is greater than or equal to 0.48, add a define for cross-compile purposes
-valac_version = run_command('valac', ['--version'])
-if valac_version.stdout().split().get(1).version_compare('>=0.48.0')
+if meson.get_compiler('vala').version().version_compare('>=0.48.0')
   add_project_arguments(['--define=VALAC048'], language: 'vala')
   message('Using VALAC048')
 endif


### PR DESCRIPTION
meson.build assumes incorrectly that the name of valac compiler is always 'valac' (in the path), while the name can be set up thru env variable VALAC. Meson build system deals with VALAC correctly, falling back to defaults if VALAC is not set.