### PR TITLE
Ask what to do when saving file with conflicts

### DIFF
--- a/src/Document.vala
+++ b/src/Document.vala
@@ -116,12 +116,32 @@ public class Document : Object {
     return( found );
   }
 
+  private Xml.Doc* load_raw() {
+      return Xml.Parser.read_file( filename, null, Xml.ParserOption.HUGE );
+  }
+
+  private string get_etag(Xml.Doc* doc) {
+    for (Xml.Attr* prop = doc->get_root_element()->properties; prop != null; prop = prop->next) {
+      string attr_name = prop->name;
+      if ( attr_name != "etag" ) {
+        continue;
+      }
+
+      return prop->children->content;
+    }
+    return generate_etag();
+  }
+
   /* Opens the given filename */
   public bool load() {
-    Xml.Doc* doc = Xml.Parser.read_file( filename, null, Xml.ParserOption.HUGE );
+    Xml.Doc* doc = load_raw();
     if( doc == null ) {
       return( false );
     }
+
+    /* Load Etag */
+    _etag = get_etag(doc);
+
     _da.load( doc->get_root_element() );
     delete doc;
     return( true );

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -962,6 +962,40 @@ public class MainWindow : Hdy.ApplicationWindow {
 
   }
 
+  /* Displays the overwrite warning dialog window.
+   * Returns true when overwrite is wanted and false when reload is wanted. */
+  public bool ask_modified_overwrite( DrawArea da ) {
+
+    var dialog = new Granite.MessageDialog.with_image_from_icon_name(
+      _( "The file %s was modified outside of the application." ).printf( da.get_doc().filename ),
+      _( "What do you want to do?" ),
+      "dialog-warning",
+      ButtonsType.NONE
+    );
+
+    var dont = new Button.with_label( _( "Discard Changes and reload" ) );
+    dialog.add_action_widget( dont, ResponseType.CLOSE );
+
+    var save = new Button.with_label( _( "Save local version and overwrite" ) );
+    dialog.add_action_widget( save, ResponseType.ACCEPT );
+
+    dialog.set_transient_for( this );
+    dialog.set_title( "Overwrite or reload?" );
+
+    dialog.show_all();
+
+    var res = dialog.run();
+
+    dialog.destroy();
+
+    switch( res ) {
+      case ResponseType.ACCEPT :  return true;
+      case ResponseType.CLOSE  :  return false;
+    }
+
+    return( false );
+  }
+
   /*
    Creates a new file
   */


### PR DESCRIPTION
This series adds couple of things to the Minder save file behavior:

There is a new Etag attribute for the root XML element. The value is opaque and has no meaning (see what HTTP does [1]). The Etag changes every time a new version is saved.

[1] https://en.wikipedia.org/wiki/HTTP_ETag

When saving a file, the Etag is first loaded from the on-disk version and compared to the live Etag Minder knows about. There can be one of the following outcomes:

1) When the on-disk and in-memory Etag match, file is saved as usual

2) When the on-disk and in-memory Etag differ a dialog is shown asking the user what to do:

- Save the local file and overwrite the conflicting copy
OR
- Ignore the local version and reload the version from disk

In both cases the other version is backed up as well so the user can recover his data in case he makes a bad choice.

Possible future enhancement is enabling a file watch and reloading the local file when no local modifications exist and the in-memory version is the logical predecessor of the on-disk version.

This at least partially fixes #412