### PR TITLE
Zoom in place

### DIFF
--- a/src/Animator.vala
+++ b/src/Animator.vala
@@ -80,6 +80,13 @@ public class Animator : Object {
     }
   }
 
+  /* Animates a change to both the canvas scale while keeping a screen location stable */
+  public void add_scale_in_place( string name, double ssx, double ssy ) {
+    if( (_actions.length == 0) || (_actions.peek_tail().type() != AnimationType.PANSCALE) ) {
+      _actions.push_tail( new AnimatorScaleInPlace( _da, name, ssx, ssy ) );
+    }
+  }
+
   /*
    This should be called whenever the drawing area wants to queue an immediate draw.
    This function will force all of the queued animations to complete immediately.

--- a/src/DrawArea.vala
+++ b/src/DrawArea.vala
@@ -1805,10 +1805,9 @@ public class DrawArea : Gtk.DrawingArea {
         continue;
       }
 
-      //animator.add_scale( "zoom in" );
+      animator.add_scale_in_place( "zoom in place", zoom_x, zoom_y );
       set_scaling_factor_coord( mark / 100, zoom_x, zoom_y );
-      //animator.animate();
-      queue_draw();
+      animator.animate();
       return( true );
     }
     return( false );
@@ -1840,10 +1839,9 @@ public class DrawArea : Gtk.DrawingArea {
         continue;
       }
 
-      //animator.add_scale( "zoom out" );
+      animator.add_scale_in_place( "zoom out in place", zoom_x, zoom_y );
       set_scaling_factor_coord( last / 100, zoom_x, zoom_y );
-      //animator.animate();
-      queue_draw();
+      animator.animate();
       return( true );
     }
     return( false );

--- a/src/animator/AnimatorScaleInPlace.vala
+++ b/src/animator/AnimatorScaleInPlace.vala
@@ -1,0 +1,72 @@
+/*
+* Copyright (c) 2021 (https://github.com/phase1geo/Minder)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Martin Sivak <mars@montik.net>
+*/
+
+using GLib;
+
+public class AnimatorScaleInPlace : AnimatorAction {
+
+  private double? _sscale = null;  // Starting scaling factor
+  private double? _escale = null;  // Ending scaling factor
+  private double? _ssx = null;     // Screen X to keep stable
+  private double? _ssy = null;     // Screen X to keep stable
+  private double? _dx = null;      // Document X to keep stable
+  private double? _dy = null;      // Document Y to keep stable
+
+  /* Constructor for a pan change */
+  public AnimatorScaleInPlace( DrawArea da, string name, double ssx, double ssy ) {
+    base( name );
+
+    double? _sox = null;     // Starting origin X
+    double? _soy = null;     // Starting origin Y
+    da.get_origin( out _sox, out _soy );
+
+    _sscale = da.sfactor;
+    _ssx = ssx;
+    _ssy = ssy;
+    _dx = _sox + _ssx / _sscale;
+    _dy = _soy + _ssy / _sscale;
+  }
+
+  /* Returns the NODES types */
+  public override AnimationType type() {
+    return( AnimationType.PANSCALE );
+  }
+
+  /* User method which performs the animation */
+  public override void capture( DrawArea da ) {
+    _escale = da.sfactor;
+  }
+
+  /* Adjusts the origin for the given frame */
+  public override void adjust( DrawArea da ) {
+    double divisor = index / frames;
+    index++;
+    double sf = _sscale + ((_escale - _sscale) * divisor);
+    da.sfactor = sf;
+
+    double newo_x = _dx - _ssx / sf;
+    double newo_y = _dy - _ssy / sf;
+
+    da.set_origin( newo_x, newo_y );
+  }
+
+}
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,6 +5,7 @@ sources += files(
     'animator/AnimatorPanScale.vala',
     'animator/AnimatorPositions.vala',
     'animator/AnimatorScale.vala',
+    'animator/AnimatorScaleInPlace.vala',
 
     'exports/ExportCSV.vala',
     'exports/ExportFreemind.vala',


### PR DESCRIPTION
Fixes #379

The zoom methods got new arguments for the position that should be maintained stable. The original methods were updated to use these new methods with the position of center of the screen to avoid code duplication.

This also adds a new Animator that supports this zoom behavior.