### PR TITLE
Improve sticker search

### DIFF
--- a/src/StickerInspector.vala
+++ b/src/StickerInspector.vala
@@ -297,7 +297,13 @@ public class StickerInspector : Box {
     /* Otherwise, show only the currently matching icons */
     } else {
       _matched_box.set_filter_func((item) => {
-        return( item.get_child().get_tooltip_text().contains( search_text ) );
+        var search_keys = search_text.split(" ");
+        foreach (string sk in search_keys) {
+          if ( !item.get_child().get_tooltip_text().casefold().contains( sk ) ) {
+            return( false );
+          }
+        }
+        return( true );
       });
       _stack.set_visible_child_name( "matched" );
     }


### PR DESCRIPTION
1. Case insensitive
![case-insensitive](https://user-images.githubusercontent.com/2861357/150623922-fc19c649-d471-4f5f-9b84-1fb7e1ae7c9f.gif)

2. Use space-separated query to provide a fuzzy-scoped search
For example: To find the "Old time camera" sticker, we can type "cam" first to list stickers whose name contains "cam", then use "old" to filter them again
![fuzzy-scoped](https://user-images.githubusercontent.com/2861357/150624070-6a67c21a-9a1b-49fa-ba20-87bc0e3ef066.gif)
.