### PR TITLE
Fix typo in Node.import_opml that breaks note attr parsing

### DIFF
--- a/src/Node.vala
+++ b/src/Node.vala
@@ -1309,7 +1309,7 @@ public class Node : Object {
     }
 
     /* Get the note information */
-    string? o = parent->get_prop( "node" );
+    string? o = parent->get_prop( "note" );
     if( o != null ) {
       note = o;
     }


### PR DESCRIPTION
As the export method and the OPML schema suggests, the name of the attribute with the notes should be `note` instead of `node`.