### PR TITLE
update get_tag_index() function

### DIFF
--- a/src/Tags.vala
+++ b/src/Tags.vala
@@ -165,7 +165,8 @@ public class Tags {
   // cannot be found.
   public int get_tag_index( Tag tag ) {
     for( int i=0; i<_tags.length; i++ ) {
-      if( _tags.index( i ) == tag ) {
+      var curr_tag = _tags.index( i );
+      if( (curr_tag == tag) || (curr_tag.name == tag.name) ) {
         return( i );
       }
     }


### PR DESCRIPTION
Fix #722 

the == operation for a `Tag` object was checking for reference equivalence rather than the relevant data equivalence (the name string of the Tag). I think it was defaulting to the -1 index because of this and so having a problem later, disallowing the user to load the program (kinda scary). It originally allowed to add multiple tags of the same tag to the same node also, but this should stop it.

So far I haven't been able to recreate the start-up crash with this change.