### PR TITLE
Add distinction between movement and letter keys

### DIFF
--- a/src/Shortcuts.vala
+++ b/src/Shortcuts.vala
@@ -150,12 +150,23 @@ public class Shortcut {
 
   //-------------------------------------------------------------
   // Returns true if this shortcut matches the given match values
-  public bool matches_keypress( bool control, bool shift, bool alt, uint[] kvs, MapState state ) {
+  public bool matches_keypress( bool control, bool shift, bool alt, uint keyval, uint[] kvs, MapState state ) {
+    var match = false;
+    if( _keycode >= 0xff00 && _keycode <= 0xffff ) {
+      var event_keyval = keyval;
+      if( event_keyval == Key.ISO_Left_Tab ) {
+        event_keyval = Key.Tab;
+      }
+      match = (event_keyval == _keycode);
+    } else {
+      match = has_key( kvs );
+    }
+
     return(
       (_control == control) &&
       (_shift   == shift)   &&
       (_alt     == alt)     &&
-      has_key( kvs )        &&
+      match                 &&
       MapState.matches( state, _command )
     );
   }
@@ -386,7 +397,7 @@ public class Shortcuts {
     Display.get_default().map_keycode( keycode, out ks, out kvs );
 
     for( int i=0; i<_shortcuts.length; i++ ) {
-      if( _shortcuts.index( i ).matches_keypress( control, shift, alt, kvs, state ) ) {
+      if( _shortcuts.index( i ).matches_keypress( control, shift, alt, keyval, kvs, state ) ) {
         _shortcuts.index( i ).execute( map );
         return( true );
       }


### PR DESCRIPTION
Fixes #732

- Add a condition to check whether the pressed key is a symbol or movement key in matches_keypress
- Update the execute function to match the signature of matches_keypress

Test ran:

1. With my [custom keyboard layout][keyboard-layout], I opened Minder;
2. I pressed Enter on the root node to validate that text is saved;
3. I pressed E (which is also up arrow key for me if I press AltGr) and successfully edited the text.

[keyboard-layout]: https://codeberg.org/argothth/dotfiles/src/commit/ffaf7ecf4c7f5a45987c1740bbf1b53fa361274a/.config/xkb/symbols/us#L98