### PR TITLE
Add LaTeX formula rendering to canvas text

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Use the power of mind-mapping to make your ideas come to life.
 - Choose from many tree layout choices.
 - Support for Markdown formatting.
 - Support for insertion of Unicode characters.
+- Typeset full-node LaTeX expressions to scalable SVG using `$$...$$` delimiters.
 - Add notes, tasks, and images to your nodes.
 - Add node-to-node connections with optional text and notes.
 - Stylize nodes, callouts, links and connections to add more meaning and improve readability.
@@ -51,9 +52,22 @@ You will need the following dependencies to build Minder:
 * libarchive-dev
 * libgtksourceview-5-dev
 * libmarkdown2-dev
+* librsvg2-dev
 * libjson-glib-dev
 * libwebp-dev
-* webp-pixbuf-loader`
+* webp-pixbuf-loader
+* A LaTeX installation providing `latex`, `amsmath`, `amssymb` and `dvisvgm`
+
+To typeset a formula in a node, connection title, or callout, make the entire
+text value a display LaTeX expression. For example:
+
+```latex
+$$\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$
+```
+
+Minder displays the source while it is being edited and renders it as a
+scalable SVG when editing finishes. If the LaTeX tools are unavailable or the
+expression is invalid, Minder leaves the source visible.
 
 To install, run `sudo ./app install` and then run the application from your application launcher or from
 the command-line with `./app run`.  If you want to debug with gdb using this build, run `./app debug`.

--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ is drawn as an inline scalable SVG. If the LaTeX tools are unavailable or an
 expression is invalid, Minder leaves that source visible.
 
 If the optional `formulaocr-offline` command is installed, pasting a formula
-image converts it locally to editable `$$...$$` source and then renders it as
-SVG. Recognition is asynchronous and does not require an internet connection.
-Use **Paste and Replace** when you want to keep clipboard content as an image;
-set `MINDER_FORMULA_OCR` to select a different local recognizer executable.
+image with **Ctrl+Shift+V** converts it locally to editable `$$...$$` source
+and then renders it as SVG. Ordinary **Ctrl+V** keeps its usual behavior,
+including pasting clipboard images as images. Recognition is asynchronous and
+does not require an internet connection. Set `MINDER_FORMULA_OCR` to select a
+different local recognizer executable.
 
 To install, run `sudo ./app install` and then run the application from your application launcher or from
 the command-line with `./app run`.  If you want to debug with gdb using this build, run `./app debug`.

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ be used in a text value. For example:
 This is a formula $$\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$
 ```
 
-Minder displays the source while it is being edited and renders the combined
-text and formulas as a scalable SVG when editing finishes. If the LaTeX tools
-are unavailable or an expression is invalid, Minder leaves the source visible.
+Minder displays the source while it is being edited. When editing finishes,
+ordinary and Markdown-formatted text remains native Pango text and each formula
+is drawn as an inline scalable SVG. If the LaTeX tools are unavailable or an
+expression is invalid, Minder leaves that source visible.
 
 If the optional `formulaocr-offline` command is installed, pasting a formula
 image converts it locally to editable `$$...$$` source and then renders it as

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Use the power of mind-mapping to make your ideas come to life.
 - Choose from many tree layout choices.
 - Support for Markdown formatting.
 - Support for insertion of Unicode characters.
-- Typeset full-node LaTeX expressions to scalable SVG using `$$...$$` delimiters.
+- Typeset inline LaTeX expressions to scalable SVG using `$$...$$` delimiters.
 - Add notes, tasks, and images to your nodes.
 - Add node-to-node connections with optional text and notes.
 - Stylize nodes, callouts, links and connections to add more meaning and improve readability.
@@ -58,16 +58,17 @@ You will need the following dependencies to build Minder:
 * webp-pixbuf-loader
 * A LaTeX installation providing `latex`, `amsmath`, `amssymb` and `dvisvgm`
 
-To typeset a formula in a node, connection title, or callout, make the entire
-text value a display LaTeX expression. For example:
+To typeset a formula in a node, connection title, or callout, surround it with
+`$$` delimiters. Formulas can be mixed with ordinary text and more than one can
+be used in a text value. For example:
 
 ```latex
-$$\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$
+This is a formula $$\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$
 ```
 
-Minder displays the source while it is being edited and renders it as a
-scalable SVG when editing finishes. If the LaTeX tools are unavailable or the
-expression is invalid, Minder leaves the source visible.
+Minder displays the source while it is being edited and renders the combined
+text and formulas as a scalable SVG when editing finishes. If the LaTeX tools
+are unavailable or an expression is invalid, Minder leaves the source visible.
 
 To install, run `sudo ./app install` and then run the application from your application launcher or from
 the command-line with `./app run`.  If you want to debug with gdb using this build, run `./app debug`.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Minder displays the source while it is being edited and renders the combined
 text and formulas as a scalable SVG when editing finishes. If the LaTeX tools
 are unavailable or an expression is invalid, Minder leaves the source visible.
 
+If the optional `formulaocr-offline` command is installed, pasting a formula
+image converts it locally to editable `$$...$$` source and then renders it as
+SVG. Recognition is asynchronous and does not require an internet connection.
+Use **Paste and Replace** when you want to keep clipboard content as an image;
+set `MINDER_FORMULA_OCR` to select a different local recognizer executable.
+
 To install, run `sudo ./app install` and then run the application from your application launcher or from
 the command-line with `./app run`.  If you want to debug with gdb using this build, run `./app debug`.
 

--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,7 @@ math_dep = cc.find_library('m', required: false)
 
 # Check libmarkdown2 dependency
 libmarkdown = dependency('libmarkdown', required: true)
+librsvg = dependency('librsvg-2.0', version: '>=2.52', required: true)
 markdown_vapi = '/vapi/libmarkdown.vapi'
 if libmarkdown.version().version_compare('>=3.0')
   add_project_arguments(['--define=MD30'], language: 'vala')
@@ -67,6 +68,7 @@ dependencies = [
     dependency('json-glib-1.0'),
     dependency('libwebp'),
     libmarkdown,
+    librsvg,
     math_dep
 ]
 

--- a/meson.build
+++ b/meson.build
@@ -74,6 +74,18 @@ dependencies = [
 
 subdir('tests')
 
+test_executable = executable(
+  'minder-regress',
+  test_vala_sources,
+  files('src/LatexSpanParser.vala'),
+  dependencies: dependencies,
+)
+
+test(
+  'minder-regress',
+  test_executable,
+)
+
 e = executable('com.github.phase1geo.minder',
     sources,
     config_file,

--- a/src/CanvasText.vala
+++ b/src/CanvasText.vala
@@ -39,6 +39,7 @@ public class CanvasText : Object {
   private int           _column        = 0;   // Character column to use when moving vertically
   private Pango.Layout  _pango_layout  = null;
   private Pango.Layout  _line_layout   = null;
+  private LatexRenderer _latex         = null;
   private int           _selstart      = 0;
   private int           _selend        = 0;
   private int           _selanchor     = 0;
@@ -107,6 +108,7 @@ public class CanvasText : Object {
         _edit = value;
         if( !_edit ) {
           _nomarkup_text = new FormattedText.copy_clean( _map, _text );
+          _latex.update( _text.text, _font_size );
           clear_selection( "edit" );
         }
         update_size( true );
@@ -142,6 +144,7 @@ public class CanvasText : Object {
   public CanvasText( MindMap map ) {
     int int_max_width = (int)_max_width;
     _map           = map;
+    initialize_latex();
     _text          = new FormattedText( map );
     _text.changed.connect( text_changed );
     _nomarkup_text = new FormattedText( map );
@@ -158,6 +161,7 @@ public class CanvasText : Object {
   public CanvasText.with_text( MindMap map, string txt ) {
     int int_max_width = (int)_max_width;
     _map           = map;
+    initialize_latex();
     _text          = new FormattedText.with_text( map, txt );
     _text.changed.connect( text_changed );
     _nomarkup_text = new FormattedText.copy_clean( map, _text );
@@ -166,7 +170,17 @@ public class CanvasText : Object {
     _pango_layout.set_wrap( Pango.WrapMode.WORD_CHAR );
     _pango_layout.set_width( int_max_width * Pango.SCALE );
     initialize_font_description();
+    _latex.update( txt, _font_size );
     update_size( false );
+  }
+
+  //-------------------------------------------------------------
+  // Creates the SVG-backed LaTeX renderer.
+  private void initialize_latex() {
+    _latex = new LatexRenderer();
+    _latex.changed.connect(() => {
+      update_size( true );
+    });
   }
 
   //-------------------------------------------------------------
@@ -192,6 +206,7 @@ public class CanvasText : Object {
     _pango_layout.set_font_description( ct._pango_layout.get_font_description() );
     _pango_layout.set_alignment( ct._pango_layout.get_alignment() );
     _pango_layout.set_width( int_max_width * Pango.SCALE );
+    _latex.update( _text.text, _font_size );
     update_size( true );
   }
 
@@ -215,6 +230,9 @@ public class CanvasText : Object {
     fd.set_size( int_fsize );
     _line_layout.set_font_description( fd );
     _pango_layout.set_font_description( fd );
+    if( !edit ) {
+      _latex.update( _text.text, _font_size );
+    }
     update_size( true );
   }
 
@@ -321,6 +339,7 @@ public class CanvasText : Object {
       if( (it->type == Xml.ElementType.ELEMENT_NODE) && (it->name == "text" ) )  {
         _text.load( it );
         _nomarkup_text = new FormattedText.copy_clean( _map, _text );
+        _latex.update( _text.text, _font_size );
         update_size( false );
       }
     }
@@ -337,6 +356,9 @@ public class CanvasText : Object {
   // Returns the number of pixels to include on the current page
   // of this text item
   public double get_page_include_size( int page_size ) {
+    if( !edit && _latex.valid ) {
+      return( _height );
+    }
     Pango.Rectangle ink_rect, log_rect;
     var line_count = _pango_layout.get_line_count();
     for( int i=0; i<line_count; i++ ) {
@@ -355,6 +377,7 @@ public class CanvasText : Object {
   private void text_changed() {
     if( !edit ) {
       _nomarkup_text = new FormattedText.copy_clean( _map, _text );
+      _latex.update( _text.text, _font_size );
     }
     update_size( true );
   }
@@ -363,12 +386,18 @@ public class CanvasText : Object {
   // Updates the width and height based on the current text.
   public void update_size( bool call_resized = true ) {
     if( _pango_layout != null ) {
-      int text_width, text_height;
-      _pango_layout.set_text( (edit ? _text.text : _nomarkup_text.text), -1 );
-      _pango_layout.set_attributes( edit ? _text.get_attributes() : _nomarkup_text.get_attributes() );
-      _pango_layout.get_size( out text_width, out text_height );
-      _width  = (text_width  / Pango.SCALE);
-      _height = (text_height / Pango.SCALE);
+      if( !edit && _latex.valid ) {
+        var scale = Math.fmin( 1.0, (_max_width / _latex.width) );
+        _width  = _latex.width  * scale;
+        _height = _latex.height * scale;
+      } else {
+        int text_width, text_height;
+        _pango_layout.set_text( (edit ? _text.text : _nomarkup_text.text), -1 );
+        _pango_layout.set_attributes( edit ? _text.get_attributes() : _nomarkup_text.get_attributes() );
+        _pango_layout.get_size( out text_width, out text_height );
+        _width  = (text_width  / Pango.SCALE);
+        _height = (text_height / Pango.SCALE);
+      }
       if( call_resized ) {
         resized();
       }
@@ -1148,6 +1177,11 @@ public class CanvasText : Object {
   //-------------------------------------------------------------
   // Draws the node font to the screen
   public void draw( Cairo.Context ctx, Theme theme, RGBA fg, double alpha, bool copy_layout ) {
+
+    if( !edit && _latex.valid ) {
+      _latex.draw( ctx, posx, posy, _width, _height, fg, alpha );
+      return;
+    }
 
     var layout = _pango_layout;
 

--- a/src/CanvasText.vala
+++ b/src/CanvasText.vala
@@ -108,7 +108,7 @@ public class CanvasText : Object {
         _edit = value;
         if( !_edit ) {
           _nomarkup_text = new FormattedText.copy_clean( _map, _text );
-          _latex.update( _text.text, _font_size );
+          _latex.update( _nomarkup_text, _font_size );
           clear_selection( "edit" );
         }
         update_size( true );
@@ -150,6 +150,7 @@ public class CanvasText : Object {
     _nomarkup_text = new FormattedText( map );
     _line_layout   = map.canvas.create_pango_layout( "M" );
     _pango_layout  = map.canvas.create_pango_layout( null );
+    _latex.attach( _pango_layout.get_context() );
     _pango_layout.set_wrap( Pango.WrapMode.WORD_CHAR );
     _pango_layout.set_width( int_max_width * Pango.SCALE );
     initialize_font_description();
@@ -167,10 +168,11 @@ public class CanvasText : Object {
     _nomarkup_text = new FormattedText.copy_clean( map, _text );
     _line_layout   = map.canvas.create_pango_layout( "M" );
     _pango_layout  = map.canvas.create_pango_layout( txt );
+    _latex.attach( _pango_layout.get_context() );
     _pango_layout.set_wrap( Pango.WrapMode.WORD_CHAR );
     _pango_layout.set_width( int_max_width * Pango.SCALE );
     initialize_font_description();
-    _latex.update( txt, _font_size );
+    _latex.update( _nomarkup_text, _font_size );
     update_size( false );
   }
 
@@ -206,7 +208,7 @@ public class CanvasText : Object {
     _pango_layout.set_font_description( ct._pango_layout.get_font_description() );
     _pango_layout.set_alignment( ct._pango_layout.get_alignment() );
     _pango_layout.set_width( int_max_width * Pango.SCALE );
-    _latex.update( _text.text, _font_size );
+    _latex.update( _nomarkup_text, _font_size );
     update_size( true );
   }
 
@@ -231,7 +233,7 @@ public class CanvasText : Object {
     _line_layout.set_font_description( fd );
     _pango_layout.set_font_description( fd );
     if( !edit ) {
-      _latex.update( _text.text, _font_size );
+      _latex.update( _nomarkup_text, _font_size );
     }
     update_size( true );
   }
@@ -339,7 +341,7 @@ public class CanvasText : Object {
       if( (it->type == Xml.ElementType.ELEMENT_NODE) && (it->name == "text" ) )  {
         _text.load( it );
         _nomarkup_text = new FormattedText.copy_clean( _map, _text );
-        _latex.update( _text.text, _font_size );
+        _latex.update( _nomarkup_text, _font_size );
         update_size( false );
       }
     }
@@ -356,9 +358,6 @@ public class CanvasText : Object {
   // Returns the number of pixels to include on the current page
   // of this text item
   public double get_page_include_size( int page_size ) {
-    if( !edit && _latex.valid ) {
-      return( _height );
-    }
     Pango.Rectangle ink_rect, log_rect;
     var line_count = _pango_layout.get_line_count();
     for( int i=0; i<line_count; i++ ) {
@@ -377,7 +376,7 @@ public class CanvasText : Object {
   private void text_changed() {
     if( !edit ) {
       _nomarkup_text = new FormattedText.copy_clean( _map, _text );
-      _latex.update( _text.text, _font_size );
+      _latex.update( _nomarkup_text, _font_size );
     }
     update_size( true );
   }
@@ -386,18 +385,17 @@ public class CanvasText : Object {
   // Updates the width and height based on the current text.
   public void update_size( bool call_resized = true ) {
     if( _pango_layout != null ) {
-      if( !edit && _latex.valid ) {
-        var scale = Math.fmin( 1.0, (_max_width / _latex.width) );
-        _width  = _latex.width  * scale;
-        _height = _latex.height * scale;
-      } else {
-        int text_width, text_height;
-        _pango_layout.set_text( (edit ? _text.text : _nomarkup_text.text), -1 );
-        _pango_layout.set_attributes( edit ? _text.get_attributes() : _nomarkup_text.get_attributes() );
-        _pango_layout.get_size( out text_width, out text_height );
-        _width  = (text_width  / Pango.SCALE);
-        _height = (text_height / Pango.SCALE);
+      int text_width, text_height;
+      var layout_text = edit ? _text : _nomarkup_text;
+      var attrs       = layout_text.get_attributes();
+      if( !edit ) {
+        _latex.apply_attributes( layout_text.text, ref attrs );
       }
+      _pango_layout.set_text( layout_text.text, -1 );
+      _pango_layout.set_attributes( attrs );
+      _pango_layout.get_size( out text_width, out text_height );
+      _width  = (text_width  / Pango.SCALE);
+      _height = (text_height / Pango.SCALE);
       if( call_resized ) {
         resized();
       }
@@ -408,7 +406,12 @@ public class CanvasText : Object {
   // Updates the canvas item with the given theme
   public void update_attributes() {
     if( _pango_layout != null ) {
-      _pango_layout.set_attributes( edit ? _text.get_attributes() : _nomarkup_text.get_attributes() );
+      var layout_text = edit ? _text : _nomarkup_text;
+      var attrs       = layout_text.get_attributes();
+      if( !edit ) {
+        _latex.apply_attributes( layout_text.text, ref attrs );
+      }
+      _pango_layout.set_attributes( attrs );
     }
   }
 
@@ -1178,22 +1181,22 @@ public class CanvasText : Object {
   // Draws the node font to the screen
   public void draw( Cairo.Context ctx, Theme theme, RGBA fg, double alpha, bool copy_layout ) {
 
-    if( !edit && _latex.valid ) {
-      _latex.draw( ctx, posx, posy, _width, _height, fg, alpha );
-      return;
-    }
-
     var layout = _pango_layout;
 
     if( copy_layout || node_selected ) {
       layout = _pango_layout.copy();
-      layout.set_attributes( edit ? _text.get_attributes_from_theme( theme, node_selected ) :
-                                    _nomarkup_text.get_attributes_from_theme( theme, node_selected ) );
+      var layout_text = edit ? _text : _nomarkup_text;
+      var attrs       = layout_text.get_attributes_from_theme( theme, node_selected );
+      if( !edit ) {
+        _latex.apply_attributes( layout_text.text, ref attrs );
+      }
+      layout.set_attributes( attrs );
     }
 
     if( alpha < 1.0 ) {
-      layout = _pango_layout.copy();
-      var attrs      = layout.get_attributes();
+      layout = layout.copy();
+      var current_attrs = layout.get_attributes();
+      var attrs      = (current_attrs == null) ? new Pango.AttrList() : current_attrs.copy();
       var alpha_val  = (uint16)(65536 * alpha);
       var alpha_attr = Pango.attr_foreground_alpha_new( alpha_val );
       alpha_attr.start_index = 0;
@@ -1208,6 +1211,7 @@ public class CanvasText : Object {
     // Output the text
     ctx.move_to( (posx - (log_rect.x / Pango.SCALE)), posy );
     Utils.set_context_color_with_alpha( ctx, fg, alpha );
+    _latex.prepare_draw( fg, alpha );
     Pango.cairo_show_layout( ctx, layout );
     ctx.new_path();
 

--- a/src/Clipboard.vala
+++ b/src/Clipboard.vala
@@ -95,7 +95,7 @@ public class MinderClipboard {
 
   //-------------------------------------------------------------
   // Called to paste current item in clipboard to the given DrawArea
-  public static void paste( MindMap map, bool shift ) {
+  public static void paste( MindMap map, bool replace, bool recognize_formula = false ) {
 
     var clipboard   = Display.get_default().get_clipboard();
     var text_needed = map.is_node_editable() || map.is_connection_editable();
@@ -106,7 +106,7 @@ public class MinderClipboard {
           string str;
           var stream = clipboard.read_async.end( res, out str );
           var contents = Utils.read_stream( stream );
-          map.model.paste_nodes( contents, shift );
+          map.model.paste_nodes( contents, replace );
         } catch( Error e ) {}
       });
     } else if( clipboard.get_formats().contain_mime_type( "image/png" ) || !text_needed ) {
@@ -115,7 +115,7 @@ public class MinderClipboard {
           var texture = clipboard.read_texture_async.end( res );
           if( texture != null ) {
             var pixbuf = Utils.texture_to_pixbuf( texture );
-            if( !shift && FormulaRecognizer.available() ) {
+            if( recognize_formula && FormulaRecognizer.available() ) {
               map.win.notification(
                 _( "Recognizing formula" ),
                 _( "Converting the pasted image to editable LaTeX locally" )
@@ -138,7 +138,7 @@ public class MinderClipboard {
                 }
               });
             } else {
-              map.model.paste_image( pixbuf, shift );
+              map.model.paste_image( pixbuf, replace );
             }
           }
         } catch( Error e ) {}
@@ -147,7 +147,7 @@ public class MinderClipboard {
       clipboard.read_text_async.begin( null, (obj, res) => {
         try {
           var text = clipboard.read_text_async.end( res );
-          map.model.paste_text( text, shift );
+          map.model.paste_text( text, replace );
         } catch( Error e ) {}
       });
     }

--- a/src/Clipboard.vala
+++ b/src/Clipboard.vala
@@ -115,7 +115,31 @@ public class MinderClipboard {
           var texture = clipboard.read_texture_async.end( res );
           if( texture != null ) {
             var pixbuf = Utils.texture_to_pixbuf( texture );
-            map.model.paste_image( pixbuf, true );
+            if( !shift && FormulaRecognizer.available() ) {
+              map.win.notification(
+                _( "Recognizing formula" ),
+                _( "Converting the pasted image to editable LaTeX locally" )
+              );
+              FormulaRecognizer.recognize.begin( pixbuf, (obj, result) => {
+                try {
+                  var formula = FormulaRecognizer.recognize.end( result );
+                  map.model.paste_text( "$$%s$$".printf( formula ), false );
+                  map.win.notification(
+                    _( "Formula recognized" ),
+                    _( "The pasted image was converted to editable LaTeX" )
+                  );
+                } catch( Error e ) {
+                  warning( "Unable to recognize pasted formula: %s", e.message );
+                  map.model.paste_image( pixbuf, false );
+                  map.win.notification(
+                    _( "Pasted as an image" ),
+                    _( "Formula recognition was skipped: %s" ).printf( e.message )
+                  );
+                }
+              });
+            } else {
+              map.model.paste_image( pixbuf, shift );
+            }
           }
         } catch( Error e ) {}
       });

--- a/src/FormattedText.vala
+++ b/src/FormattedText.vala
@@ -574,7 +574,7 @@ public class FormattedText {
   // Tag representing header text.
   private class HeaderInfo : TagAttr {
     public HeaderInfo() {}
-    private double get_scale_factor( string? extra ) {
+    public static double get_scale_factor( string? extra ) {
       switch( extra ) {
         case "1" :  return( 2.1 );
         case "2" :  return( 1.8 );
@@ -1002,6 +1002,15 @@ public class FormattedText {
   // Returns true if the given tag is applied at the given index.
   public bool is_tag_applied_at_index( FormatTag tag, int index ) {
     return( _formats[tag].is_applied_at_index( index ) );
+  }
+
+  //-------------------------------------------------------------
+  // Returns the relative font scale applied at the given index.
+  public double get_font_scale_at_index( int index ) {
+    if( !_formats[FormatTag.HEADER].is_applied_at_index( index ) ) {
+      return( 1.0 );
+    }
+    return( HeaderInfo.get_scale_factor( _formats[FormatTag.HEADER].get_extra( index ) ) );
   }
 
   //-------------------------------------------------------------

--- a/src/FormulaRecognizer.vala
+++ b/src/FormulaRecognizer.vala
@@ -1,0 +1,130 @@
+/*
+* Copyright (c) 2018-2026 (https://github.com/phase1geo/Minder)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*/
+
+using Gdk;
+using GLib;
+
+//-------------------------------------------------------------
+// Runs the optional local formula recognizer without blocking the UI.
+public class FormulaRecognizer : Object {
+
+  private const int COMMAND_TIMEOUT  = 30;
+  private const int MAX_OUTPUT_BYTES = 32768;
+  private static bool _busy          = false;
+
+  //-------------------------------------------------------------
+  // Finds either the explicitly configured recognizer or the default command.
+  private static string? find_command() {
+    var configured = Environment.get_variable( "MINDER_FORMULA_OCR" );
+    if( (configured != null) && (configured.strip() != "") ) {
+      if( configured.contains( "/" ) ) {
+        return( FileUtils.test( configured, FileTest.IS_EXECUTABLE ) ? configured : null );
+      }
+      return( Environment.find_program_in_path( configured ) );
+    }
+    return( Environment.find_program_in_path( "formulaocr-offline" ) );
+  }
+
+  //-------------------------------------------------------------
+  // Returns true when formula recognition is installed.
+  public static bool available() {
+    return( find_command() != null );
+  }
+
+  //-------------------------------------------------------------
+  // Recognizes a single pixbuf and returns unwrapped LaTeX source.
+  public static async string recognize( Pixbuf image ) throws Error {
+    var command = find_command();
+    if( command == null ) {
+      throw new IOError.NOT_FOUND( _( "The offline formula recognizer is not installed" ) );
+    }
+    if( _busy ) {
+      throw new IOError.BUSY( _( "Another formula is already being recognized" ) );
+    }
+
+    string? temp_dir  = null;
+    string? image_path = null;
+    _busy = true;
+    try {
+      temp_dir  = DirUtils.make_tmp( "minder-formula-ocr-XXXXXX" );
+      image_path = GLib.Path.build_filename( temp_dir, "formula.png" );
+      image.save( image_path, "png" );
+
+      string[] argv = { command, image_path };
+      var launcher = new SubprocessLauncher(
+        SubprocessFlags.STDOUT_PIPE | SubprocessFlags.STDERR_PIPE
+      );
+      var process = launcher.spawnv( argv );
+      string? stdout_buf = null;
+      string? stderr_buf = null;
+      var timed_out = false;
+      var timeout_id = Timeout.add_seconds( COMMAND_TIMEOUT, () => {
+        timed_out = true;
+        process.force_exit();
+        return( Source.REMOVE );
+      });
+
+      try {
+        yield process.communicate_utf8_async( null, null, out stdout_buf, out stderr_buf );
+      } finally {
+        if( !timed_out ) {
+          Source.remove( timeout_id );
+        }
+      }
+
+      if( timed_out ) {
+        throw new IOError.TIMED_OUT( _( "Offline formula recognition timed out" ) );
+      }
+      if( !process.get_successful() ) {
+        throw new IOError.FAILED(
+          compact_error( stderr_buf ?? stdout_buf ?? _( "Offline formula recognition failed" ) )
+        );
+      }
+
+      var formula = (stdout_buf ?? "").strip();
+      if( formula == "" ) {
+        throw new IOError.INVALID_DATA( _( "The formula recognizer returned no LaTeX" ) );
+      }
+      if( formula.length > MAX_OUTPUT_BYTES ) {
+        throw new IOError.INVALID_DATA( _( "The recognized formula is too long" ) );
+      }
+      return( formula );
+    } finally {
+      _busy = false;
+      if( image_path != null ) {
+        FileUtils.remove( image_path );
+      }
+      if( temp_dir != null ) {
+        DirUtils.remove( temp_dir );
+      }
+    }
+  }
+
+  //-------------------------------------------------------------
+  // Keeps process errors readable in notifications and logs.
+  private static string compact_error( string message ) {
+    var stripped = message.strip();
+    var chars = stripped.char_count();
+    if( chars <= 500 ) {
+      return( stripped );
+    }
+    return( stripped.substring( stripped.index_of_nth_char( chars - 500 ) ) );
+  }
+
+}

--- a/src/KeyCommands.vala
+++ b/src/KeyCommands.vala
@@ -212,6 +212,7 @@ public enum KeyCommand {
       EDIT_COPY,
       EDIT_CUT,
       EDIT_PASTE,
+      EDIT_PASTE_LATEX,
     EDIT_CLIPBOARD_END,
     EDIT_URL_START,
       EDIT_OPEN_URL,  // 170
@@ -399,6 +400,7 @@ public enum KeyCommand {
       case EDIT_COPY                 :  return( "edit-copy" );
       case EDIT_CUT                  :  return( "edit-cut" );
       case EDIT_PASTE                :  return( "edit-paste" );
+      case EDIT_PASTE_LATEX          :  return( "edit-paste-latex" );
       case EDIT_OPEN_URL             :  return( "edit-open-url" );
       case EDIT_ADD_URL              :  return( "edit-add-url" );
       case EDIT_EDIT_URL             :  return( "edit-edit-url" );
@@ -571,6 +573,7 @@ public enum KeyCommand {
       case "edit-copy"                 :  return( EDIT_COPY );
       case "edit-cut"                  :  return( EDIT_CUT );
       case "edit-paste"                :  return( EDIT_PASTE );
+      case "edit-paste-latex"          :  return( EDIT_PASTE_LATEX );
       case "edit-open-url"             :  return( EDIT_OPEN_URL );
       case "edit-add-url"              :  return( EDIT_ADD_URL );
       case "edit-edit-url"             :  return( EDIT_EDIT_URL );
@@ -760,6 +763,7 @@ public enum KeyCommand {
       case EDIT_COPY                 :  return( _( "Copy selected nodes or text" ) );
       case EDIT_CUT                  :  return( _( "Cut selected nodes or text" ) );
       case EDIT_PASTE                :  return( _( "Paste nodes or text from clipboard" ) );
+      case EDIT_PASTE_LATEX          :  return( _( "Convert a clipboard image to LaTeX" ) );
       case EDIT_URL_START            :  return( _( "URL Commands" ) );
       case EDIT_OPEN_URL             :  return( _( "Open URL link at current cursor position" ) );
       case EDIT_ADD_URL              :  return( _( "Add URL link at current cursor position" ) );
@@ -931,6 +935,7 @@ public enum KeyCommand {
       case EDIT_COPY                 :  return( edit_copy );
       case EDIT_CUT                  :  return( edit_cut );
       case EDIT_PASTE                :  return( edit_paste );
+      case EDIT_PASTE_LATEX          :  return( edit_paste_latex );
       case EDIT_OPEN_URL             :  return( edit_open_url );
       case EDIT_ADD_URL              :  return( edit_add_url );
       case EDIT_EDIT_URL             :  return( edit_edit_url );
@@ -981,6 +986,7 @@ public enum KeyCommand {
       (this == EDIT_COPY) ||
       (this == EDIT_CUT)  ||
       (this == EDIT_PASTE) ||
+      (this == EDIT_PASTE_LATEX) ||
       (this == ESCAPE)
     );
   }
@@ -1043,6 +1049,7 @@ public enum KeyCommand {
       case NODE_ADD_SIBLING_BEFORE :
       case NODE_SELECT_ROOT        :
       case EDIT_PASTE              :
+      case EDIT_PASTE_LATEX        :
       case ESCAPE                  :
         return( true );
       default :
@@ -2364,6 +2371,11 @@ public enum KeyCommand {
   public static void edit_paste( MindMap map ) {
     if( !map.editable ) return;
     map.do_paste( false );
+  }
+
+  public static void edit_paste_latex( MindMap map ) {
+    if( !map.editable ) return;
+    map.do_paste_latex();
   }
 
   private static void edit_return_helper( MindMap map, bool shift ) {

--- a/src/LatexRenderer.vala
+++ b/src/LatexRenderer.vala
@@ -1,0 +1,390 @@
+/*
+* Copyright (c) 2018-2026 (https://github.com/phase1geo/Minder)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License as
+* published by the Free Software Foundation; either version 2 of
+* the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Trevor Williams <phase1geo@gmail.com>
+*/
+
+using Cairo;
+using Gdk;
+using Gee;
+using GLib;
+
+//-------------------------------------------------------------
+// Converts display LaTeX to SVG and renders the result to Cairo.
+public class LatexRenderer : Object {
+
+  private class LatexImage : Object {
+    public Rsvg.Handle handle { get; private set; }
+    public double      width  { get; private set; }
+    public double      height { get; private set; }
+    public LatexImage( Rsvg.Handle handle, double width, double height ) {
+      this.handle = handle;
+      this.width  = width;
+      this.height = height;
+    }
+  }
+
+  private const int MAX_SOURCE_LENGTH = 16384;
+  private const int MAX_CACHE_ITEMS   = 128;
+  private const int COMMAND_TIMEOUT   = 10;
+
+  private static HashMap<string,LatexImage>? _cache = null;
+
+  private LatexImage? _image      = null;
+  private Subprocess? _process    = null;
+  private string      _key        = "";
+  private int         _generation = 0;
+  private bool        _rendering  = false;
+  private string?     _error      = null;
+
+  public bool valid {
+    get {
+      return( _image != null );
+    }
+  }
+  public bool rendering {
+    get {
+      return( _rendering );
+    }
+  }
+  public double width {
+    get {
+      return( (_image == null) ? 0.0 : _image.width );
+    }
+  }
+  public double height {
+    get {
+      return( (_image == null) ? 0.0 : _image.height );
+    }
+  }
+  public string? error {
+    get {
+      return( _error );
+    }
+  }
+
+  public signal void changed();
+
+  //-------------------------------------------------------------
+  // Returns true and extracts the expression when the entire value
+  // is enclosed by display-math delimiters.
+  public static bool parse_source( string source, out string expression ) {
+    var stripped = source.strip();
+    expression = "";
+    if( (stripped.length < 5) || !stripped.has_prefix( "$$" ) || !stripped.has_suffix( "$$" ) ) {
+      return( false );
+    }
+    expression = stripped.substring( 2, (stripped.length - 4) ).strip();
+    return( expression != "" );
+  }
+
+  //-------------------------------------------------------------
+  // Returns true if the supplied text is a display LaTeX expression.
+  public static bool is_latex_source( string source ) {
+    string expression;
+    return( parse_source( source, out expression ) );
+  }
+
+  //-------------------------------------------------------------
+  // Returns true while the user is entering a display expression.
+  // This keeps other backslash-based input helpers from consuming
+  // LaTeX commands before the closing delimiter has been entered.
+  public static bool is_latex_candidate( string source ) {
+    return( source.strip().has_prefix( "$$" ) );
+  }
+
+  //-------------------------------------------------------------
+  // Updates the rendered image. Rendering runs asynchronously so a
+  // complex expression cannot block canvas interaction.
+  public void update( string source, int font_size ) {
+    string expression;
+    if( !parse_source( source, out expression ) ) {
+      clear();
+      return;
+    }
+
+    var size = int.max( 6, font_size );
+    var key  = "%d\x1f%s".printf( size, expression );
+    if( key == _key ) {
+      return;
+    }
+
+    cancel();
+    _key   = key;
+    _error = null;
+
+    if( _cache == null ) {
+      _cache = new HashMap<string,LatexImage>();
+    }
+    if( _cache.has_key( key ) ) {
+      _image = _cache.get( key );
+      changed();
+      return;
+    }
+
+    if( expression.length > MAX_SOURCE_LENGTH ) {
+      fail( key, _generation, _( "LaTeX expression is too long" ) );
+      return;
+    }
+
+    var latex   = Environment.find_program_in_path( "latex" );
+    var dvisvgm = Environment.find_program_in_path( "dvisvgm" );
+    if( (latex == null) || (dvisvgm == null) ) {
+      fail( key, _generation, _( "LaTeX rendering requires the latex and dvisvgm commands" ) );
+      return;
+    }
+
+    _rendering = true;
+    render.begin( expression, size, key, _generation, latex, dvisvgm );
+  }
+
+  //-------------------------------------------------------------
+  // Clears any current or pending render.
+  private void clear() {
+    if( (_key == "") && (_image == null) && !_rendering && (_error == null) ) {
+      return;
+    }
+    cancel();
+    _key   = "";
+    _image = null;
+    _error = null;
+    changed();
+  }
+
+  //-------------------------------------------------------------
+  // Cancels the current subprocess and invalidates its callbacks.
+  private void cancel() {
+    _generation++;
+    if( _process != null ) {
+      _process.force_exit();
+      _process = null;
+    }
+    _rendering = false;
+    _image     = null;
+  }
+
+  //-------------------------------------------------------------
+  // Creates the small standalone TeX document used by latex.
+  private static string make_document( string expression, int font_size ) {
+    var line_height = font_size * 1.2;
+    return( """\documentclass{article}
+\usepackage{amsmath}
+\usepackage{amssymb}
+\pagestyle{empty}
+\begin{document}
+\fontsize{%dpt}{%.2fpt}\selectfont
+\(\displaystyle
+%s
+\)
+\end{document}
+""".printf( font_size, line_height, expression ) );
+  }
+
+  //-------------------------------------------------------------
+  // Runs latex followed by dvisvgm and loads the resulting SVG.
+  private async void render( string expression, int font_size, string key, int generation,
+                             string latex, string dvisvgm ) {
+    string? temp_dir = null;
+    try {
+      temp_dir = DirUtils.make_tmp( "minder-latex-XXXXXX" );
+      var tex_file = GLib.Path.build_filename( temp_dir, "formula.tex" );
+      FileUtils.set_contents( tex_file, make_document( expression, font_size ) );
+
+      string command_error;
+      string[] latex_argv = {
+        latex,
+        "-interaction=nonstopmode",
+        "-halt-on-error",
+        "-no-shell-escape",
+        "formula.tex"
+      };
+      if( !(yield run_command( temp_dir, latex_argv, generation, out command_error )) ) {
+        fail( key, generation, command_error );
+        return;
+      }
+      if( generation != _generation ) {
+        return;
+      }
+
+      string[] svg_argv = {
+        dvisvgm,
+        "--no-fonts=0",
+        "--exact-bbox",
+        "--bbox=min",
+        "--no-specials",
+        "--verbosity=0",
+        "--output=formula.svg",
+        "formula.dvi"
+      };
+      if( !(yield run_command( temp_dir, svg_argv, generation, out command_error )) ) {
+        fail( key, generation, command_error );
+        return;
+      }
+      if( generation != _generation ) {
+        return;
+      }
+
+      var handle = new Rsvg.Handle.from_file( GLib.Path.build_filename( temp_dir, "formula.svg" ) );
+      handle.set_dpi( 96.0 );
+      double width, height;
+      if( !handle.get_intrinsic_size_in_pixels( out width, out height ) || (width <= 0) || (height <= 0) ) {
+        fail( key, generation, _( "The generated LaTeX SVG has no usable size" ) );
+        return;
+      }
+
+      var image = new LatexImage( handle, width, height );
+      if( _cache.size >= MAX_CACHE_ITEMS ) {
+        _cache.clear();
+      }
+      _cache.set( key, image );
+      if( (generation == _generation) && (key == _key) ) {
+        _image     = image;
+        _rendering = false;
+        _error     = null;
+        changed();
+      }
+    } catch( Error e ) {
+      fail( key, generation, e.message );
+    } finally {
+      if( temp_dir != null ) {
+        remove_temp_dir( temp_dir );
+      }
+    }
+  }
+
+  //-------------------------------------------------------------
+  // Runs one renderer command with a timeout and restricted TeX IO.
+  private async bool run_command( string working_dir, string[] argv, int generation, out string command_error ) {
+    command_error = "";
+    string? stdout_buf = null;
+    string? stderr_buf = null;
+    bool timed_out = false;
+
+    try {
+      var flags    = SubprocessFlags.STDOUT_PIPE | SubprocessFlags.STDERR_PIPE;
+      var launcher = new SubprocessLauncher( flags );
+      launcher.set_cwd( working_dir );
+      launcher.setenv( "openin_any",  "p", true );
+      launcher.setenv( "openout_any", "p", true );
+      launcher.setenv( "TEXMFOUTPUT", working_dir, true );
+      var process = launcher.spawnv( argv );
+      _process = process;
+
+      uint timeout_id = Timeout.add_seconds( COMMAND_TIMEOUT, () => {
+        timed_out = true;
+        process.force_exit();
+        return( Source.REMOVE );
+      });
+
+      try {
+        yield process.communicate_utf8_async( null, null, out stdout_buf, out stderr_buf );
+      } finally {
+        if( !timed_out ) {
+          Source.remove( timeout_id );
+        }
+      }
+
+      if( _process == process ) {
+        _process = null;
+      }
+      if( generation != _generation ) {
+        command_error = _( "LaTeX rendering was cancelled" );
+        return( false );
+      }
+      if( timed_out ) {
+        command_error = _( "LaTeX rendering timed out" );
+        return( false );
+      }
+      if( !process.get_successful() ) {
+        command_error = compact_error( stderr_buf ?? stdout_buf ?? _( "LaTeX rendering failed" ) );
+        return( false );
+      }
+      return( true );
+    } catch( Error e ) {
+      command_error = e.message;
+      return( false );
+    }
+  }
+
+  //-------------------------------------------------------------
+  // Keeps command diagnostics useful without retaining a full TeX log.
+  private static string compact_error( string message ) {
+    var stripped = message.strip();
+    var chars = stripped.char_count();
+    if( chars <= 500 ) {
+      return( stripped );
+    }
+    return( stripped.substring( stripped.index_of_nth_char( chars - 500 ) ) );
+  }
+
+  //-------------------------------------------------------------
+  // Records a render failure if it still belongs to the active source.
+  private void fail( string key, int generation, string message ) {
+    if( (generation == _generation) && (key == _key) ) {
+      _image     = null;
+      _rendering = false;
+      _error     = message;
+      warning( "Unable to render LaTeX: %s", message );
+      changed();
+    }
+  }
+
+  //-------------------------------------------------------------
+  // Removes only files created inside our private temporary directory.
+  private static void remove_temp_dir( string path ) {
+    try {
+      var dir = Dir.open( path );
+      unowned string? name;
+      while( (name = dir.read_name()) != null ) {
+        FileUtils.remove( GLib.Path.build_filename( path, name ) );
+      }
+    } catch( FileError e ) {}
+    DirUtils.remove( path );
+  }
+
+  //-------------------------------------------------------------
+  // Renders the cached SVG at the requested canvas location and color.
+  public void draw( Context ctx, double x, double y, double draw_width, double draw_height,
+                    RGBA color, double alpha ) {
+    if( _image == null ) return;
+
+    var red   = (int)(color.red   * 255.0);
+    var green = (int)(color.green * 255.0);
+    var blue  = (int)(color.blue  * 255.0);
+    var css   = "* { fill: rgb(%d, %d, %d) !important; }".printf( red, green, blue );
+
+    try {
+      _image.handle.set_stylesheet( css.data );
+      Rsvg.Rectangle viewport = {x, y, draw_width, draw_height};
+      ctx.save();
+      if( alpha < 1.0 ) {
+        ctx.push_group();
+      }
+      _image.handle.render_document( ctx, viewport );
+      if( alpha < 1.0 ) {
+        ctx.pop_group_to_source();
+        ctx.paint_with_alpha( alpha );
+      }
+      ctx.restore();
+      ctx.new_path();
+    } catch( Error e ) {
+      warning( "Unable to draw LaTeX SVG: %s", e.message );
+    }
+  }
+
+}

--- a/src/LatexRenderer.vala
+++ b/src/LatexRenderer.vala
@@ -25,246 +25,374 @@ using Gee;
 using GLib;
 
 //-------------------------------------------------------------
-// Converts text containing LaTeX spans to SVG and renders it to Cairo.
+// Renders $$...$$ spans as inline Pango shapes while leaving all
+// ordinary and Markdown-formatted text in the normal Pango layout.
 public class LatexRenderer : Object {
 
   private class LatexImage : Object {
-    public Rsvg.Handle handle { get; private set; }
-    public double      width  { get; private set; }
-    public double      height { get; private set; }
-    public LatexImage( Rsvg.Handle handle, double width, double height ) {
-      this.handle = handle;
-      this.width  = width;
-      this.height = height;
+    public Rsvg.Handle handle        { get; private set; }
+    public double      width         { get; private set; }
+    public double      ascent        { get; private set; }
+    public double      descent       { get; private set; }
+    public double      render_width  { get; private set; }
+    public double      render_height { get; private set; }
+    public LatexImage( Rsvg.Handle handle, double width, double ascent, double descent,
+                       double render_width, double render_height ) {
+      this.handle        = handle;
+      this.width         = width;
+      this.ascent        = ascent;
+      this.descent       = descent;
+      this.render_width  = render_width;
+      this.render_height = render_height;
+    }
+  }
+
+  private class LatexSpan : Object {
+    public int         start      { get; private set; }
+    public int         end        { get; private set; }
+    public string      expression { get; private set; }
+    public string      key        { get; private set; }
+    public double      font_size  { get; private set; }
+    public LatexImage? image      { get; set; default = null; }
+    public Subprocess? process    { get; set; default = null; }
+    public LatexSpan( int start, int end, string expression, string key, double font_size ) {
+      this.start      = start;
+      this.end        = end;
+      this.expression = expression;
+      this.key        = key;
+      this.font_size  = font_size;
+    }
+  }
+
+  private class ShapeData : Object {
+    public LatexRenderer owner { get; private set; }
+    public LatexImage?   image { get; private set; }
+    public bool          draw  { get; private set; }
+    public ShapeData( LatexRenderer owner, LatexImage? image, bool draw ) {
+      this.owner = owner;
+      this.image = image;
+      this.draw  = draw;
+    }
+  }
+
+  private class RenderJob : Object {
+    public LatexRenderer owner      { get; private set; }
+    public LatexSpan     span       { get; private set; }
+    public int           generation { get; private set; }
+    public string        latex      { get; private set; }
+    public string        dvisvgm    { get; private set; }
+    public RenderJob( LatexRenderer owner, LatexSpan span, int generation,
+                      string latex, string dvisvgm ) {
+      this.owner      = owner;
+      this.span       = span;
+      this.generation = generation;
+      this.latex      = latex;
+      this.dvisvgm    = dvisvgm;
     }
   }
 
   private const int MAX_SOURCE_LENGTH = 16384;
   private const int MAX_CACHE_ITEMS   = 128;
   private const int COMMAND_TIMEOUT   = 10;
+  private const int MAX_ACTIVE_JOBS   = 2;
 
   private static HashMap<string,LatexImage>? _cache = null;
+  private static GLib.Queue<RenderJob>?       _render_queue = null;
+  private static int                          _active_jobs  = 0;
 
-  private LatexImage? _image      = null;
-  private Subprocess? _process    = null;
-  private string      _key        = "";
-  private int         _generation = 0;
-  private bool        _rendering  = false;
-  private string?     _error      = null;
-
-  public bool valid {
-    get {
-      return( _image != null );
-    }
-  }
-  public bool rendering {
-    get {
-      return( _rendering );
-    }
-  }
-  public double width {
-    get {
-      return( (_image == null) ? 0.0 : _image.width );
-    }
-  }
-  public double height {
-    get {
-      return( (_image == null) ? 0.0 : _image.height );
-    }
-  }
-  public string? error {
-    get {
-      return( _error );
-    }
-  }
+  private Array<LatexSpan> _spans;
+  private string           _source       = "";
+  private int              _font_size    = 12;
+  private int              _generation   = 0;
+  private double           _draw_red     = 0.0;
+  private double           _draw_green   = 0.0;
+  private double           _draw_blue    = 0.0;
+  private double           _draw_alpha   = 1.0;
 
   public signal void changed();
 
   //-------------------------------------------------------------
-  // Escapes ordinary node text before it is included in the small
-  // TeX document surrounding the formula spans.
-  private static void append_text( StringBuilder output, string text ) {
-    int index = 0;
-    unichar c;
-    while( text.get_next_char( ref index, out c ) ) {
-      switch( c ) {
-        case '\\' :  output.append( "\\textbackslash{}" );     break;
-        case '{'  :  output.append( "\\{" );                  break;
-        case '}'  :  output.append( "\\}" );                  break;
-        case '$'  :  output.append( "\\$" );                  break;
-        case '&'  :  output.append( "\\&" );                  break;
-        case '#'  :  output.append( "\\#" );                  break;
-        case '%'  :  output.append( "\\%" );                  break;
-        case '_'  :  output.append( "\\_" );                  break;
-        case '^'  :  output.append( "\\textasciicircum{}" );  break;
-        case '~'  :  output.append( "\\textasciitilde{}" );   break;
-        case '\n' :  output.append( "\\strut\\\\\n" );      break;
-        case '\r' :                                            break;
-        default   :  output.append_unichar( c );                break;
-      }
+  // Default constructor.
+  public LatexRenderer() {
+    _spans = new Array<LatexSpan>();
+    if( _cache == null ) {
+      _cache = new HashMap<string,LatexImage>();
+    }
+    if( _render_queue == null ) {
+      _render_queue = new GLib.Queue<RenderJob>();
     }
   }
 
   //-------------------------------------------------------------
-  // Converts one or more $$...$$ spans into a safe TeX document body.
-  // Text outside the spans is treated as literal text, not TeX source.
-  public static bool parse_source( string source, out string document_body ) {
-    var output       = new StringBuilder( "\\noindent\\strut " );
-    var offset       = 0;
-    var formula_seen = false;
-
-    while( offset < source.length ) {
-      var start = source.index_of( "$$", offset );
-      if( start == -1 ) {
-        append_text( output, source.substring( offset ) );
-        break;
-      }
-
-      append_text( output, source.substring( offset, (start - offset) ) );
-      var end = source.index_of( "$$", (start + 2) );
-      if( end == -1 ) {
-        document_body = "";
-        return( false );
-      }
-
-      var expression = source.substring( (start + 2), (end - start - 2) ).strip();
-      if( expression == "" ) {
-        document_body = "";
-        return( false );
-      }
-
-      output.append( "\\(\\displaystyle\n" );
-      output.append( expression );
-      output.append( "\n\\)" );
-      formula_seen = true;
-      offset = end + 2;
-    }
-
-    document_body = output.str;
-    return( formula_seen );
+  // Installs the one shape callback used by this Pango context.
+  public void attach( Pango.Context context ) {
+    Pango.cairo_context_set_shape_renderer( context, draw_shape );
   }
 
   //-------------------------------------------------------------
-  // Returns true if the supplied text is a display LaTeX expression.
-  public static bool is_latex_source( string source ) {
-    string document_body;
-    return( parse_source( source, out document_body ) );
-  }
-
-  //-------------------------------------------------------------
-  // Returns true when a byte position is inside an opened $$ span.
-  // This also handles the span while its closing delimiter is pending.
-  public static bool is_latex_at( string source, int position ) {
-    var offset  = 0;
-    var in_math = false;
-    while( offset < source.length ) {
-      var delimiter = source.index_of( "$$", offset );
-      if( delimiter == -1 ) {
-        return( in_math );
-      }
-      if( position < delimiter ) {
-        return( in_math );
-      }
-      in_math = !in_math;
-      offset = delimiter + 2;
-    }
-    return( in_math );
-  }
-
-  //-------------------------------------------------------------
-  // Updates the rendered image. Rendering runs asynchronously so a
-  // complex expression cannot block canvas interaction.
-  public void update( string source, int font_size ) {
-    string document_body;
-    if( !parse_source( source, out document_body ) ) {
-      clear();
-      return;
-    }
-
-    var size = int.max( 6, font_size );
-    var key  = "%d\x1f%s".printf( size, source );
-    if( key == _key ) {
+  // Updates the list of inline formulas and starts missing renders.
+  public void update( FormattedText formatted, int font_size ) {
+    var source = formatted.text;
+    var size   = int.max( 6, font_size );
+    if( (source == _source) && (size == _font_size) ) {
       return;
     }
 
     cancel();
-    _key   = key;
-    _error = null;
-
-    if( _cache == null ) {
-      _cache = new HashMap<string,LatexImage>();
-    }
-    if( _cache.has_key( key ) ) {
-      _image = _cache.get( key );
-      changed();
-      return;
-    }
+    _source    = source;
+    _font_size = size;
 
     if( source.length > MAX_SOURCE_LENGTH ) {
-      fail( key, _generation, _( "LaTeX expression is too long" ) );
       return;
+    }
+
+    var offset = 0;
+    while( offset < source.length ) {
+      var start = LatexSpanParser.find_delimiter( source, offset );
+      if( start == -1 ) {
+        break;
+      }
+      var close = LatexSpanParser.find_delimiter( source, start + 2 );
+      if( close == -1 ) {
+        break;
+      }
+      var end        = close + 2;
+      var expression = source.substring( start + 2, close - start - 2 ).strip();
+      if( expression == "" ) {
+        offset = end;
+        continue;
+      }
+
+      // Markdown code spans remain ordinary text, including any dollar signs.
+      if( !formatted.is_tag_applied_at_index( FormatTag.CODE, start ) ) {
+        var span_size = Math.fmax( 6.0, size * formatted.get_font_scale_at_index( start ) );
+        var key       = "%.2f\x1f%s".printf( span_size, expression );
+        var span      = new LatexSpan( start, end, expression, key, span_size );
+        if( _cache.has_key( key ) ) {
+          span.image = _cache.get( key );
+        }
+        _spans.append_val( span );
+      }
+      offset = end;
     }
 
     var latex   = Environment.find_program_in_path( "latex" );
     var dvisvgm = Environment.find_program_in_path( "dvisvgm" );
     if( (latex == null) || (dvisvgm == null) ) {
-      fail( key, _generation, _( "LaTeX rendering requires the latex and dvisvgm commands" ) );
       return;
     }
 
-    _rendering = true;
-    render.begin( document_body, size, key, _generation, latex, dvisvgm );
+    for( int i=0; i<_spans.length; i++ ) {
+      var span = _spans.index( i );
+      if( span.image == null ) {
+        _render_queue.push_tail( new RenderJob( this, span, _generation, latex, dvisvgm ) );
+      }
+    }
+    dispatch_jobs();
   }
 
   //-------------------------------------------------------------
-  // Clears any current or pending render.
-  private void clear() {
-    if( (_key == "") && (_image == null) && !_rendering && (_error == null) ) {
+  // Starts queued jobs without allowing a large document to launch
+  // an unbounded number of TeX processes at once.
+  private static void dispatch_jobs() {
+    while( (_active_jobs < MAX_ACTIVE_JOBS) && !_render_queue.is_empty() ) {
+      var job = _render_queue.pop_head();
+      if( (job.generation == job.owner._generation) && (job.span.image == null) ) {
+        start_job( job );
+      }
+    }
+  }
+
+  //-------------------------------------------------------------
+  // Runs one queued job and releases its slot on completion.
+  private static void start_job( RenderJob job ) {
+    _active_jobs++;
+    job.owner.render.begin(
+      job.span, job.generation, job.latex, job.dvisvgm,
+      (obj, result) => {
+        job.owner.render.end( result );
+        _active_jobs--;
+        dispatch_jobs();
+      }
+    );
+  }
+
+  //-------------------------------------------------------------
+  // Adds inline formula shapes to a normal Pango attribute list.
+  public void apply_attributes( string source, ref Pango.AttrList attrs ) {
+    for( int i=0; i<_spans.length; i++ ) {
+      var span = _spans.index( i );
+      if( span.image == null ) {
+        continue;
+      }
+
+      var first_end = span.start;
+      unichar first_character;
+      if( !source.get_next_char( ref first_end, out first_character ) || (first_end > span.end) ) {
+        continue;
+      }
+
+      var width   = (int)Math.ceil( span.image.width * Pango.SCALE );
+      var ascent  = (int)Math.ceil( span.image.ascent * Pango.SCALE );
+      var descent = (int)Math.ceil( span.image.descent * Pango.SCALE );
+      Pango.Rectangle rectangle = {0, -ascent, width, ascent + descent};
+      var visible_data = new ShapeData( this, span.image, true );
+      var visible = new Pango.AttrShape<ShapeData>.with_data(
+        rectangle, rectangle, visible_data, copy_shape_data
+      );
+      visible.start_index = (uint)span.start;
+      visible.end_index   = (uint)first_end;
+      attrs.insert( (owned)visible );
+
+      // The first character owns the formula width and drawing.  The rest of
+      // the source is replaced by zero-width shapes, preserving byte offsets.
+      if( first_end < span.end ) {
+        Pango.Rectangle hidden_rectangle = {0, 0, 0, 0};
+        var hidden_data = new ShapeData( this, null, false );
+        var hidden = new Pango.AttrShape<ShapeData>.with_data(
+          hidden_rectangle, hidden_rectangle, hidden_data, copy_shape_data
+        );
+        hidden.start_index = (uint)first_end;
+        hidden.end_index   = (uint)span.end;
+        attrs.insert( (owned)hidden );
+      }
+
+      var no_breaks = Pango.attr_allow_breaks_new( false );
+      no_breaks.start_index = (uint)span.start;
+      no_breaks.end_index   = (uint)span.end;
+      attrs.insert( (owned)no_breaks );
+
+      var no_hyphens = Pango.attr_insert_hyphens_new( false );
+      no_hyphens.start_index = (uint)span.start;
+      no_hyphens.end_index   = (uint)span.end;
+      attrs.insert( (owned)no_hyphens );
+    }
+  }
+
+  //-------------------------------------------------------------
+  // Stores the color used by the next Pango draw operation.
+  public void prepare_draw( RGBA color, double alpha ) {
+    _draw_red   = color.red;
+    _draw_green = color.green;
+    _draw_blue  = color.blue;
+    _draw_alpha = alpha;
+  }
+
+  //-------------------------------------------------------------
+  // Copies the data attached to a shape when Pango copies a layout.
+  private static ShapeData copy_shape_data( ShapeData data ) {
+    return( new ShapeData( data.owner, data.image, data.draw ) );
+  }
+
+  //-------------------------------------------------------------
+  // Draws an inline SVG at the current Pango baseline.
+  private static void draw_shape( Cairo.Context ctx, Pango.AttrShape attribute, bool do_path ) {
+    unowned Pango.AttrShape<ShapeData> shape = (Pango.AttrShape<ShapeData>)attribute;
+    var data = shape.data;
+    if( do_path || !data.draw || (data.image == null) ) {
       return;
     }
-    cancel();
-    _key   = "";
-    _image = null;
-    _error = null;
-    changed();
+    data.owner.draw_image( ctx, data.image );
   }
 
   //-------------------------------------------------------------
-  // Cancels the current subprocess and invalidates its callbacks.
+  // Draws the image represented by a shape callback.
+  private void draw_image( Cairo.Context ctx, LatexImage image ) {
+    double x, baseline;
+    ctx.get_current_point( out x, out baseline );
+    var y     = baseline - image.render_height + image.descent;
+    var red   = (int)(_draw_red   * 255.0);
+    var green = (int)(_draw_green * 255.0);
+    var blue  = (int)(_draw_blue  * 255.0);
+    var css   = "* { fill: rgb(%d, %d, %d) !important; }".printf( red, green, blue );
+
+    try {
+      image.handle.set_stylesheet( css.data );
+      Rsvg.Rectangle viewport = {x, y, image.render_width, image.render_height};
+      ctx.save();
+      if( _draw_alpha < 1.0 ) {
+        ctx.push_group();
+      }
+      image.handle.render_document( ctx, viewport );
+      if( _draw_alpha < 1.0 ) {
+        ctx.pop_group_to_source();
+        ctx.paint_with_alpha( _draw_alpha );
+      }
+      ctx.restore();
+    } catch( Error e ) {
+      warning( "Unable to draw inline LaTeX: %s", e.message );
+    }
+  }
+
+  //-------------------------------------------------------------
+  // Cancels active renders and invalidates their callbacks.
   private void cancel() {
     _generation++;
-    if( _process != null ) {
-      _process.force_exit();
-      _process = null;
+    for( int i=0; i<_spans.length; i++ ) {
+      var process = _spans.index( i ).process;
+      if( process != null ) {
+        process.force_exit();
+      }
     }
-    _rendering = false;
-    _image     = null;
+    _spans.remove_range( 0, _spans.length );
   }
 
   //-------------------------------------------------------------
-  // Creates the small standalone TeX document used by latex.
-  private static string make_document( string document_body, int font_size ) {
+  // Creates a small document containing exactly one math expression.
+  private static string make_document( string expression, double font_size ) {
     var line_height = font_size * 1.2;
     return( """\documentclass{article}
 \usepackage{amsmath}
 \usepackage{amssymb}
 \pagestyle{empty}
 \begin{document}
-\fontsize{%dpt}{%.2fpt}\selectfont
+\fontsize{%.2fpt}{%.2fpt}\selectfont
+\setbox0=\hbox{\(\displaystyle
 %s
+\)}
+\typeout{MINDER-METRICS:\number\wd0,\number\ht0,\number\dp0}
+\noindent\box0
 \end{document}
-""".printf( font_size, line_height, document_body ) );
+""".printf( font_size, line_height, expression ) );
   }
 
   //-------------------------------------------------------------
-  // Runs latex followed by dvisvgm and loads the resulting SVG.
-  private async void render( string document_body, int font_size, string key, int generation,
-                             string latex, string dvisvgm ) {
+  // Reads TeX box dimensions from the renderer log and converts
+  // scaled points to the CSS pixels used by librsvg at 96 DPI.
+  private static bool parse_metrics( string log, out double width,
+                                     out double ascent, out double descent ) {
+    const string prefix = "MINDER-METRICS:";
+    width = ascent = descent = 0.0;
+    var start = log.index_of( prefix );
+    if( start == -1 ) {
+      return( false );
+    }
+    start += prefix.length;
+    var end = log.index_of( "\n", start );
+    var line = ((end == -1) ? log.substring( start ) : log.substring( start, end - start )).strip();
+    var values = line.split( "," );
+    if( (values.length != 3) ||
+        !Regex.match_simple( "^[0-9]+$", values[0] ) ||
+        !Regex.match_simple( "^[0-9]+$", values[1] ) ||
+        !Regex.match_simple( "^[0-9]+$", values[2] ) ) {
+      return( false );
+    }
+
+    const double SP_TO_CSS_PIXEL = 96.0 / (72.27 * 65536.0);
+    width   = int64.parse( values[0] ) * SP_TO_CSS_PIXEL;
+    ascent  = int64.parse( values[1] ) * SP_TO_CSS_PIXEL;
+    descent = int64.parse( values[2] ) * SP_TO_CSS_PIXEL;
+    return( (width > 0.0) && ((ascent + descent) > 0.0) );
+  }
+
+  //-------------------------------------------------------------
+  // Runs LaTeX and dvisvgm for one formula span.
+  private async void render( LatexSpan span, int generation, string latex, string dvisvgm ) {
     string? temp_dir = null;
     try {
       temp_dir = DirUtils.make_tmp( "minder-latex-XXXXXX" );
       var tex_file = GLib.Path.build_filename( temp_dir, "formula.tex" );
-      FileUtils.set_contents( tex_file, make_document( document_body, font_size ) );
+      FileUtils.set_contents( tex_file, make_document( span.expression, span.font_size ) );
 
       string command_error;
       string[] latex_argv = {
@@ -274,11 +402,22 @@ public class LatexRenderer : Object {
         "-no-shell-escape",
         "formula.tex"
       };
-      if( !(yield run_command( temp_dir, latex_argv, generation, out command_error )) ) {
-        fail( key, generation, command_error );
+      if( !(yield run_command( span, temp_dir, latex_argv, generation, out command_error )) ) {
+        fail( generation, command_error );
         return;
       }
       if( generation != _generation ) {
+        return;
+      }
+
+      string log;
+      double tex_width   = 0.0;
+      double tex_ascent  = 0.0;
+      double tex_descent = 0.0;
+      var log_file = GLib.Path.build_filename( temp_dir, "formula.log" );
+      if( !FileUtils.get_contents( log_file, out log ) ||
+          !parse_metrics( log, out tex_width, out tex_ascent, out tex_descent ) ) {
+        fail( generation, _( "Unable to read LaTeX formula dimensions" ) );
         return;
       }
 
@@ -292,8 +431,8 @@ public class LatexRenderer : Object {
         "--output=formula.svg",
         "formula.dvi"
       };
-      if( !(yield run_command( temp_dir, svg_argv, generation, out command_error )) ) {
-        fail( key, generation, command_error );
+      if( !(yield run_command( span, temp_dir, svg_argv, generation, out command_error )) ) {
+        fail( generation, command_error );
         return;
       }
       if( generation != _generation ) {
@@ -302,25 +441,33 @@ public class LatexRenderer : Object {
 
       var handle = new Rsvg.Handle.from_file( GLib.Path.build_filename( temp_dir, "formula.svg" ) );
       handle.set_dpi( 96.0 );
-      double width, height;
-      if( !handle.get_intrinsic_size_in_pixels( out width, out height ) || (width <= 0) || (height <= 0) ) {
-        fail( key, generation, _( "The generated LaTeX SVG has no usable size" ) );
+      double render_width, render_height;
+      if( !handle.get_intrinsic_size_in_pixels( out render_width, out render_height ) ||
+          (render_width <= 0) || (render_height <= 0) ) {
+        fail( generation, _( "The generated LaTeX SVG has no usable size" ) );
         return;
       }
 
-      var image = new LatexImage( handle, width, height );
+      // The SVG is tightly cropped to painted glyphs, while Pango needs the
+      // logical TeX box for spacing and line height.  Keep both measurements:
+      // the former for drawing and the latter for layout and its true baseline.
+      var width   = Math.fmax( tex_width, render_width );
+      var descent = Math.fmin( tex_descent, render_height );
+      var ascent  = Math.fmax( tex_ascent, render_height - descent );
+      var image   = new LatexImage(
+        handle, width, ascent, descent, render_width, render_height
+      );
       if( _cache.size >= MAX_CACHE_ITEMS ) {
         _cache.clear();
       }
-      _cache.set( key, image );
-      if( (generation == _generation) && (key == _key) ) {
-        _image     = image;
-        _rendering = false;
-        _error     = null;
+      _cache.set( span.key, image );
+      if( generation == _generation ) {
+        span.image   = image;
+        span.process = null;
         changed();
       }
     } catch( Error e ) {
-      fail( key, generation, e.message );
+      fail( generation, e.message );
     } finally {
       if( temp_dir != null ) {
         remove_temp_dir( temp_dir );
@@ -330,7 +477,8 @@ public class LatexRenderer : Object {
 
   //-------------------------------------------------------------
   // Runs one renderer command with a timeout and restricted TeX IO.
-  private async bool run_command( string working_dir, string[] argv, int generation, out string command_error ) {
+  private async bool run_command( LatexSpan span, string working_dir, string[] argv,
+                                  int generation, out string command_error ) {
     command_error = "";
     string? stdout_buf = null;
     string? stderr_buf = null;
@@ -344,7 +492,7 @@ public class LatexRenderer : Object {
       launcher.setenv( "openout_any", "p", true );
       launcher.setenv( "TEXMFOUTPUT", working_dir, true );
       var process = launcher.spawnv( argv );
-      _process = process;
+      span.process = process;
 
       uint timeout_id = Timeout.add_seconds( COMMAND_TIMEOUT, () => {
         timed_out = true;
@@ -360,8 +508,8 @@ public class LatexRenderer : Object {
         }
       }
 
-      if( _process == process ) {
-        _process = null;
+      if( span.process == process ) {
+        span.process = null;
       }
       if( generation != _generation ) {
         command_error = _( "LaTeX rendering was cancelled" );
@@ -394,12 +542,9 @@ public class LatexRenderer : Object {
   }
 
   //-------------------------------------------------------------
-  // Records a render failure if it still belongs to the active source.
-  private void fail( string key, int generation, string message ) {
-    if( (generation == _generation) && (key == _key) ) {
-      _image     = null;
-      _rendering = false;
-      _error     = message;
+  // Reports a render failure only if it belongs to current source.
+  private void fail( int generation, string message ) {
+    if( generation == _generation ) {
       warning( "Unable to render LaTeX: %s", message );
       changed();
     }
@@ -416,36 +561,6 @@ public class LatexRenderer : Object {
       }
     } catch( FileError e ) {}
     DirUtils.remove( path );
-  }
-
-  //-------------------------------------------------------------
-  // Renders the cached SVG at the requested canvas location and color.
-  public void draw( Context ctx, double x, double y, double draw_width, double draw_height,
-                    RGBA color, double alpha ) {
-    if( _image == null ) return;
-
-    var red   = (int)(color.red   * 255.0);
-    var green = (int)(color.green * 255.0);
-    var blue  = (int)(color.blue  * 255.0);
-    var css   = "* { fill: rgb(%d, %d, %d) !important; }".printf( red, green, blue );
-
-    try {
-      _image.handle.set_stylesheet( css.data );
-      Rsvg.Rectangle viewport = {x, y, draw_width, draw_height};
-      ctx.save();
-      if( alpha < 1.0 ) {
-        ctx.push_group();
-      }
-      _image.handle.render_document( ctx, viewport );
-      if( alpha < 1.0 ) {
-        ctx.pop_group_to_source();
-        ctx.paint_with_alpha( alpha );
-      }
-      ctx.restore();
-      ctx.new_path();
-    } catch( Error e ) {
-      warning( "Unable to draw LaTeX SVG: %s", e.message );
-    }
   }
 
 }

--- a/src/LatexRenderer.vala
+++ b/src/LatexRenderer.vala
@@ -25,7 +25,7 @@ using Gee;
 using GLib;
 
 //-------------------------------------------------------------
-// Converts display LaTeX to SVG and renders the result to Cairo.
+// Converts text containing LaTeX spans to SVG and renders it to Cairo.
 public class LatexRenderer : Object {
 
   private class LatexImage : Object {
@@ -81,45 +81,108 @@ public class LatexRenderer : Object {
   public signal void changed();
 
   //-------------------------------------------------------------
-  // Returns true and extracts the expression when the entire value
-  // is enclosed by display-math delimiters.
-  public static bool parse_source( string source, out string expression ) {
-    var stripped = source.strip();
-    expression = "";
-    if( (stripped.length < 5) || !stripped.has_prefix( "$$" ) || !stripped.has_suffix( "$$" ) ) {
-      return( false );
+  // Escapes ordinary node text before it is included in the small
+  // TeX document surrounding the formula spans.
+  private static void append_text( StringBuilder output, string text ) {
+    int index = 0;
+    unichar c;
+    while( text.get_next_char( ref index, out c ) ) {
+      switch( c ) {
+        case '\\' :  output.append( "\\textbackslash{}" );     break;
+        case '{'  :  output.append( "\\{" );                  break;
+        case '}'  :  output.append( "\\}" );                  break;
+        case '$'  :  output.append( "\\$" );                  break;
+        case '&'  :  output.append( "\\&" );                  break;
+        case '#'  :  output.append( "\\#" );                  break;
+        case '%'  :  output.append( "\\%" );                  break;
+        case '_'  :  output.append( "\\_" );                  break;
+        case '^'  :  output.append( "\\textasciicircum{}" );  break;
+        case '~'  :  output.append( "\\textasciitilde{}" );   break;
+        case '\n' :  output.append( "\\strut\\\\\n" );      break;
+        case '\r' :                                            break;
+        default   :  output.append_unichar( c );                break;
+      }
     }
-    expression = stripped.substring( 2, (stripped.length - 4) ).strip();
-    return( expression != "" );
+  }
+
+  //-------------------------------------------------------------
+  // Converts one or more $$...$$ spans into a safe TeX document body.
+  // Text outside the spans is treated as literal text, not TeX source.
+  public static bool parse_source( string source, out string document_body ) {
+    var output       = new StringBuilder( "\\noindent\\strut " );
+    var offset       = 0;
+    var formula_seen = false;
+
+    while( offset < source.length ) {
+      var start = source.index_of( "$$", offset );
+      if( start == -1 ) {
+        append_text( output, source.substring( offset ) );
+        break;
+      }
+
+      append_text( output, source.substring( offset, (start - offset) ) );
+      var end = source.index_of( "$$", (start + 2) );
+      if( end == -1 ) {
+        document_body = "";
+        return( false );
+      }
+
+      var expression = source.substring( (start + 2), (end - start - 2) ).strip();
+      if( expression == "" ) {
+        document_body = "";
+        return( false );
+      }
+
+      output.append( "\\(\\displaystyle\n" );
+      output.append( expression );
+      output.append( "\n\\)" );
+      formula_seen = true;
+      offset = end + 2;
+    }
+
+    document_body = output.str;
+    return( formula_seen );
   }
 
   //-------------------------------------------------------------
   // Returns true if the supplied text is a display LaTeX expression.
   public static bool is_latex_source( string source ) {
-    string expression;
-    return( parse_source( source, out expression ) );
+    string document_body;
+    return( parse_source( source, out document_body ) );
   }
 
   //-------------------------------------------------------------
-  // Returns true while the user is entering a display expression.
-  // This keeps other backslash-based input helpers from consuming
-  // LaTeX commands before the closing delimiter has been entered.
-  public static bool is_latex_candidate( string source ) {
-    return( source.strip().has_prefix( "$$" ) );
+  // Returns true when a byte position is inside an opened $$ span.
+  // This also handles the span while its closing delimiter is pending.
+  public static bool is_latex_at( string source, int position ) {
+    var offset  = 0;
+    var in_math = false;
+    while( offset < source.length ) {
+      var delimiter = source.index_of( "$$", offset );
+      if( delimiter == -1 ) {
+        return( in_math );
+      }
+      if( position < delimiter ) {
+        return( in_math );
+      }
+      in_math = !in_math;
+      offset = delimiter + 2;
+    }
+    return( in_math );
   }
 
   //-------------------------------------------------------------
   // Updates the rendered image. Rendering runs asynchronously so a
   // complex expression cannot block canvas interaction.
   public void update( string source, int font_size ) {
-    string expression;
-    if( !parse_source( source, out expression ) ) {
+    string document_body;
+    if( !parse_source( source, out document_body ) ) {
       clear();
       return;
     }
 
     var size = int.max( 6, font_size );
-    var key  = "%d\x1f%s".printf( size, expression );
+    var key  = "%d\x1f%s".printf( size, source );
     if( key == _key ) {
       return;
     }
@@ -137,7 +200,7 @@ public class LatexRenderer : Object {
       return;
     }
 
-    if( expression.length > MAX_SOURCE_LENGTH ) {
+    if( source.length > MAX_SOURCE_LENGTH ) {
       fail( key, _generation, _( "LaTeX expression is too long" ) );
       return;
     }
@@ -150,7 +213,7 @@ public class LatexRenderer : Object {
     }
 
     _rendering = true;
-    render.begin( expression, size, key, _generation, latex, dvisvgm );
+    render.begin( document_body, size, key, _generation, latex, dvisvgm );
   }
 
   //-------------------------------------------------------------
@@ -180,7 +243,7 @@ public class LatexRenderer : Object {
 
   //-------------------------------------------------------------
   // Creates the small standalone TeX document used by latex.
-  private static string make_document( string expression, int font_size ) {
+  private static string make_document( string document_body, int font_size ) {
     var line_height = font_size * 1.2;
     return( """\documentclass{article}
 \usepackage{amsmath}
@@ -188,22 +251,20 @@ public class LatexRenderer : Object {
 \pagestyle{empty}
 \begin{document}
 \fontsize{%dpt}{%.2fpt}\selectfont
-\(\displaystyle
 %s
-\)
 \end{document}
-""".printf( font_size, line_height, expression ) );
+""".printf( font_size, line_height, document_body ) );
   }
 
   //-------------------------------------------------------------
   // Runs latex followed by dvisvgm and loads the resulting SVG.
-  private async void render( string expression, int font_size, string key, int generation,
+  private async void render( string document_body, int font_size, string key, int generation,
                              string latex, string dvisvgm ) {
     string? temp_dir = null;
     try {
       temp_dir = DirUtils.make_tmp( "minder-latex-XXXXXX" );
       var tex_file = GLib.Path.build_filename( temp_dir, "formula.tex" );
-      FileUtils.set_contents( tex_file, make_document( expression, font_size ) );
+      FileUtils.set_contents( tex_file, make_document( document_body, font_size ) );
 
       string command_error;
       string[] latex_argv = {

--- a/src/LatexSpanParser.vala
+++ b/src/LatexSpanParser.vala
@@ -1,0 +1,85 @@
+/*
+* Copyright (c) 2018-2026 (https://github.com/phase1geo/Minder)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License as
+* published by the Free Software Foundation; either version 2 of
+* the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Trevor Williams <phase1geo@gmail.com>
+*/
+
+//-------------------------------------------------------------
+// Finds and validates the $$ delimiters shared by Markdown parsing
+// and inline LaTeX rendering.
+public class LatexSpanParser {
+
+  //-------------------------------------------------------------
+  // Returns the next unescaped $$ delimiter at or after offset.
+  public static int find_delimiter( string source, int offset ) {
+    var delimiter = source.index_of( "$$", offset );
+    while( delimiter != -1 ) {
+      var slash_count = 0;
+      for( var index = delimiter - 1; (index >= 0) && (source[index] == '\\'); index-- ) {
+        slash_count++;
+      }
+      if( (slash_count % 2) == 0 ) {
+        return( delimiter );
+      }
+      delimiter = source.index_of( "$$", delimiter + 2 );
+    }
+    return( -1 );
+  }
+
+  //-------------------------------------------------------------
+  // Returns true if the source contains only complete, non-empty
+  // formula spans and at least one such span is present.
+  public static bool is_latex_source( string source ) {
+    var offset = 0;
+    var seen   = false;
+    while( offset < source.length ) {
+      var start = find_delimiter( source, offset );
+      if( start == -1 ) {
+        break;
+      }
+      var close = find_delimiter( source, start + 2 );
+      if( (close == -1) || (source.substring( start + 2, close - start - 2 ).strip() == "") ) {
+        return( false );
+      }
+      seen   = true;
+      offset = close + 2;
+    }
+    return( seen );
+  }
+
+  //-------------------------------------------------------------
+  // Returns true when a byte position is inside an opened $$ span.
+  // This also handles a span while its closing delimiter is pending.
+  public static bool is_latex_at( string source, int position ) {
+    var offset  = 0;
+    var in_math = false;
+    while( offset < source.length ) {
+      var delimiter = find_delimiter( source, offset );
+      if( delimiter == -1 ) {
+        return( in_math );
+      }
+      if( position < delimiter ) {
+        return( in_math );
+      }
+      in_math = !in_math;
+      offset = delimiter + 2;
+    }
+    return( in_math );
+  }
+
+}

--- a/src/MindMap.vala
+++ b/src/MindMap.vala
@@ -1042,8 +1042,14 @@ public class MindMap {
 
   //-------------------------------------------------------------
   // Pastes the contents of the clipboard into the current node.
-  public void do_paste( bool shift ) {
-    MinderClipboard.paste( this, shift );
+  public void do_paste( bool replace ) {
+    MinderClipboard.paste( this, replace );
+  }
+
+  //-------------------------------------------------------------
+  // Recognizes a clipboard image as LaTeX and pastes the formula.
+  public void do_paste_latex() {
+    MinderClipboard.paste( this, false, true );
   }
 
   //-------------------------------------------------------------

--- a/src/Shortcuts.vala
+++ b/src/Shortcuts.vala
@@ -594,7 +594,7 @@ public class Shortcuts {
     add_default( Key.c,            true, false, false, KeyCommand.EDIT_COPY );
     add_default( Key.x,            true, false, false, KeyCommand.EDIT_CUT );
     add_default( Key.v,            true, false, false, KeyCommand.EDIT_PASTE );
-    add_default( Key.v,            true, true,  false, KeyCommand.NODE_PASTE_REPLACE );
+    add_default( Key.v,            true, true,  false, KeyCommand.EDIT_PASTE_LATEX );
     add_default( Key.Return,       true, false, false, KeyCommand.EDIT_INSERT_NEWLINE );
     add_default( Key.BackSpace,    true, false, false, KeyCommand.EDIT_REMOVE_WORD_PREV );
     add_default( Key.Delete,       true, false, false, KeyCommand.EDIT_REMOVE_WORD_NEXT );

--- a/src/meson.build
+++ b/src/meson.build
@@ -32,6 +32,7 @@ sources += files(
     'ImageMenu.vala',
     'KeyCommands.vala',
     'LatexRenderer.vala',
+    'LatexSpanParser.vala',
     'Layout.vala',
     'Layouts.vala',
     'LinkDash.vala',

--- a/src/meson.build
+++ b/src/meson.build
@@ -30,6 +30,7 @@ sources += files(
     'ImageManager.vala',
     'ImageMenu.vala',
     'KeyCommands.vala',
+    'LatexRenderer.vala',
     'Layout.vala',
     'Layouts.vala',
     'LinkDash.vala',

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,6 +23,7 @@ sources += files(
     'Exporter.vala',
     'Exports.vala',
     'FormattedText.vala',
+    'FormulaRecognizer.vala',
     'GroupInspector.vala',
     'GroupsMenu.vala',
     'HtmlToMarkdown.vala',

--- a/src/parsers/MarkdownParser.vala
+++ b/src/parsers/MarkdownParser.vala
@@ -35,14 +35,18 @@ public class MarkdownParser : TextParser {
 
     // Lists
     add_regex( "^\\s*(\\*|\\+|\\-|[0-9]+\\.)\\s", (text, match) => {
-      add_tag( text, match, 1, FormatTag.COLOR, _map.get_theme().get_color( "markdown_listitem" ).to_string() );
+      if( !within_latex( text, match, 1 ) ) {
+        add_tag( text, match, 1, FormatTag.COLOR, _map.get_theme().get_color( "markdown_listitem" ).to_string() );
+      }
     });
 
     // Code
     add_regex( "(`)([^`]+)(`)", (text, match) => {
-      make_grey( text, match, 1 );
-      add_tag( text, match, 2, FormatTag.CODE );
-      make_grey( text, match, 3 );
+      if( !within_latex( text, match, 1 ) ) {
+        make_grey( text, match, 1 );
+        add_tag( text, match, 2, FormatTag.CODE );
+        make_grey( text, match, 3 );
+      }
     });
 
     // Bold
@@ -74,13 +78,19 @@ public class MarkdownParser : TextParser {
     add_tag( text, match, paren, FormatTag.SYNTAX );
   }
 
+  private bool within_latex( FormattedText text, MatchInfo match, int paren ) {
+    int start, end;
+    match.fetch_pos( paren, out start, out end );
+    return( LatexSpanParser.is_latex_at( text.text, start ) );
+  }
+
   private void highlight_header( FormattedText text, MatchInfo match ) {
     make_grey( text, match, 1 );
     add_tag( text, match, 0, FormatTag.HEADER, get_text( match, 1 ).length.to_string() );
   }
 
   private void highlight_bold( FormattedText text, MatchInfo match ) {
-    if( !within_tag( text, match, 1, FormatTag.CODE ) ) {
+    if( !within_latex( text, match, 1 ) && !within_tag( text, match, 1, FormatTag.CODE ) ) {
       make_grey( text, match, 1 );
       add_tag( text, match, 2, FormatTag.BOLD );
       make_grey( text, match, 3 );
@@ -88,7 +98,7 @@ public class MarkdownParser : TextParser {
   }
 
   private void highlight_italics( FormattedText text, MatchInfo match ) {
-    if( !within_tag( text, match, 1, FormatTag.CODE ) ) {
+    if( !within_latex( text, match, 1 ) && !within_tag( text, match, 1, FormatTag.CODE ) ) {
       make_grey( text, match, 1 );
       add_tag( text, match, 2, FormatTag.ITALICS );
       make_grey( text, match, 3 );
@@ -96,7 +106,7 @@ public class MarkdownParser : TextParser {
   }
 
   private void highlight_strikethrough( FormattedText text, MatchInfo match ) {
-    if( !within_tag( text, match, 1, FormatTag.CODE ) ) {
+    if( !within_latex( text, match, 1 ) && !within_tag( text, match, 1, FormatTag.CODE ) ) {
       make_grey( text, match, 1 );
       add_tag( text, match, 2, FormatTag.STRIKETHRU );
       make_grey( text, match, 3 );
@@ -104,7 +114,7 @@ public class MarkdownParser : TextParser {
   }
 
   private void highlight_highlight( FormattedText text, MatchInfo match ) {
-    if( !within_tag( text, match, 1, FormatTag.CODE ) ) {
+    if( !within_latex( text, match, 1 ) && !within_tag( text, match, 1, FormatTag.CODE ) ) {
       make_grey( text, match, 1 );
       add_tag( text, match, 2, FormatTag.HILITE, "#A98400" );
       make_grey( text, match, 3 );
@@ -112,7 +122,7 @@ public class MarkdownParser : TextParser {
   }
 
   private void highlight_url1( FormattedText text, MatchInfo match ) {
-    if( !within_tag( text, match, 1, FormatTag.CODE ) ) {
+    if( !within_latex( text, match, 1 ) && !within_tag( text, match, 1, FormatTag.CODE ) ) {
       make_grey( text, match, 1 );
       add_tag( text, match, 2, FormatTag.URL, get_text( match, 4 ) );
       make_grey( text, match, 3 );
@@ -120,7 +130,7 @@ public class MarkdownParser : TextParser {
   }
 
   private void highlight_url2( FormattedText text, MatchInfo match ) {
-    if( !within_tag( text, match, 1, FormatTag.CODE ) ) {
+    if( !within_latex( text, match, 1 ) && !within_tag( text, match, 1, FormatTag.CODE ) ) {
       make_grey( text, match, 1 );
       add_tag( text, match, 2, FormatTag.URL, get_text( match, 2 ) );
       make_grey( text, match, 5 );
@@ -128,7 +138,7 @@ public class MarkdownParser : TextParser {
   }
 
   private void highlight_url3( FormattedText text, MatchInfo match ) {
-    if( !within_tag( text, match, 1, FormatTag.CODE ) ) {
+    if( !within_latex( text, match, 1 ) && !within_tag( text, match, 1, FormatTag.CODE ) ) {
       make_grey( text, match, 1 );
       add_tag( text, match, 2, FormatTag.URL, get_text( match, 2 ) );
       make_grey( text, match, 4 );
@@ -136,7 +146,7 @@ public class MarkdownParser : TextParser {
   }
 
   private void highlight_subscript( FormattedText text, MatchInfo match ) {
-    if( !within_tag( text, match, 1, FormatTag.CODE ) ) {
+    if( !within_latex( text, match, 1 ) && !within_tag( text, match, 1, FormatTag.CODE ) ) {
       make_grey( text, match, 1 );
       add_tag( text, match, 2, FormatTag.SUB, get_text( match, 2 ) );
       make_grey( text, match, 3 );
@@ -144,7 +154,7 @@ public class MarkdownParser : TextParser {
   }
 
   private void highlight_superscript( FormattedText text, MatchInfo match ) {
-    if( !within_tag( text, match, 1, FormatTag.CODE ) ) {
+    if( !within_latex( text, match, 1 ) && !within_tag( text, match, 1, FormatTag.CODE ) ) {
       make_grey( text, match, 1 );
       add_tag( text, match, 2, FormatTag.SUPER, get_text( match, 2 ) );
       make_grey( text, match, 3 );

--- a/src/parsers/UnicodeParser.vala
+++ b/src/parsers/UnicodeParser.vala
@@ -43,7 +43,7 @@ public class UnicodeParser : TextParser {
     // LaTeX commands must remain intact while a formula is edited.
     int match_start, match_end;
     match.fetch_pos( 0, out match_start, out match_end );
-    if( LatexRenderer.is_latex_at( text.text, match_start ) ) return;
+    if( LatexSpanParser.is_latex_at( text.text, match_start ) ) return;
 
     var tag = get_text( match, 0 );
 

--- a/src/parsers/UnicodeParser.vala
+++ b/src/parsers/UnicodeParser.vala
@@ -40,6 +40,9 @@ public class UnicodeParser : TextParser {
   // Highlights the given tag.
   private void handle_code( FormattedText text, MatchInfo match ) {
 
+    // LaTeX commands must remain intact while a formula is edited.
+    if( LatexRenderer.is_latex_candidate( text.text ) ) return;
+
     var tag = get_text( match, 0 );
 
     // Highlight the tag

--- a/src/parsers/UnicodeParser.vala
+++ b/src/parsers/UnicodeParser.vala
@@ -41,7 +41,9 @@ public class UnicodeParser : TextParser {
   private void handle_code( FormattedText text, MatchInfo match ) {
 
     // LaTeX commands must remain intact while a formula is edited.
-    if( LatexRenderer.is_latex_candidate( text.text ) ) return;
+    int match_start, match_end;
+    match.fetch_pos( 0, out match_start, out match_end );
+    if( LatexRenderer.is_latex_at( text.text, match_start ) ) return;
 
     var tag = get_text( match, 0 );
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,16 +1,6 @@
-test_vala_sources = [
+test_vala_sources = files(
   'assert.vala',
   'tests.vala',
   'test-example.vala',
-]
-
-test_executable = executable(
-  'minder-regress',
-  test_vala_sources,
-  dependencies: dependencies,
-)
-
-test(
-  'minder-regress',
-  test_executable,
+  'test-latex-span-parser.vala',
 )

--- a/tests/test-latex-span-parser.vala
+++ b/tests/test-latex-span-parser.vala
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2018-2026 (https://github.com/phase1geo/Minder)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License as
+* published by the Free Software Foundation; either version 2 of
+* the License, or (at your option) any later version.
+*/
+
+namespace MinderTest {
+
+  public class LatexSpanParserTest : TestSuite {
+
+    public LatexSpanParserTest() {
+      this.add_test( "valid-source", test_valid_source );
+      this.add_test( "invalid-source", test_invalid_source );
+      this.add_test( "escaped-delimiters", test_escaped_delimiters );
+      this.add_test( "position", test_position );
+    }
+
+    private void test_valid_source() {
+      Assert.true( LatexSpanParser.is_latex_source( "before $$x_1$$ after" ) );
+      Assert.true( LatexSpanParser.is_latex_source( "$$x$$ and $$\\frac{1}{2}$$" ) );
+    }
+
+    private void test_invalid_source() {
+      Assert.false( LatexSpanParser.is_latex_source( "ordinary text" ) );
+      Assert.false( LatexSpanParser.is_latex_source( "before $$x" ) );
+      Assert.false( LatexSpanParser.is_latex_source( "before $$$$ after" ) );
+      Assert.false( LatexSpanParser.is_latex_source( "$$x$$ and $$" ) );
+    }
+
+    private void test_escaped_delimiters() {
+      Assert.false( LatexSpanParser.is_latex_source( "escaped \\$$ only" ) );
+      Assert.true( LatexSpanParser.is_latex_source( "escaped \\$$ then $$x$$" ) );
+      Assert.true( LatexSpanParser.is_latex_source( "two slashes \\\\$$x$$" ) );
+      Assert.true( LatexSpanParser.is_latex_source( "$$x \\$$ y$$" ) );
+    }
+
+    private void test_position() {
+      var source = "α before $$x_1$$ after";
+      Assert.false( LatexSpanParser.is_latex_at( source, source.index_of( "before" ) ) );
+      Assert.true( LatexSpanParser.is_latex_at( source, source.index_of( "$$" ) ) );
+      Assert.true( LatexSpanParser.is_latex_at( source, source.index_of( "x_1" ) ) );
+      Assert.false( LatexSpanParser.is_latex_at( source, source.last_index_of( "$$" ) ) );
+      Assert.true( LatexSpanParser.is_latex_at( "pending $$x", 11 ) );
+    }
+
+  }
+
+}

--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -228,6 +228,7 @@ public static int main (string[] args) {
 
   var tests = new MinderTest.TestRunner ();
   tests.add( new MinderTest.ExampleTest() );
+  tests.add( new MinderTest.LatexSpanParserTest() );
 
   exit_status = tests.run();
 


### PR DESCRIPTION
## Summary

- render `$$...$$` LaTeX spans in node text, connection titles, and callouts
- support formulas mixed with ordinary text, including multiple formula spans
- convert LaTeX output to SVG and draw it through librsvg/Cairo so SVG and PDF exports remain vector
- show editable source while editing and fall back to source when rendering is unavailable or fails
- prevent Unicode completion from consuming commands inside LaTeX spans
- optionally convert a formula image from the clipboard to editable LaTeX using the local `formulaocr-offline` command
- keep ordinary **Ctrl+V** paste behavior unchanged and run image-to-LaTeX recognition only with **Ctrl+Shift+V**

## Safety and responsiveness

- rendering and OCR run asynchronously
- invokes LaTeX with `-no-shell-escape` and restricted TeX input/output settings
- invokes dvisvgm with specials disabled
- limits LaTeX input to 16 KiB, applies subprocess timeouts, and caches recent renders
- passes OCR image paths directly as subprocess arguments without invoking a shell
- limits OCR output and falls back to pasting the original image when recognition fails

## Dependencies

- build: `librsvg-2.0 >= 2.52`
- formula rendering runtime: `latex`, `dvisvgm`, `amsmath`, and `amssymb`
- optional screenshot OCR runtime: the separate `formulaocr-offline` executable and its offline model/runtime

The OCR executable/model is not bundled by this PR. Minder discovers `formulaocr-offline` on `PATH`, or a different local executable can be selected with `MINDER_FORMULA_OCR`. If it is unavailable, Ctrl+Shift+V pastes the clipboard image normally.

The current Flatpak manifests bundle neither the LaTeX runtime nor `formulaocr-offline`. Without the TeX runtime, formula source remains visible; without the OCR package, image paste still works but recognition is unavailable.

## Testing

- full Meson application build succeeds
- regression suite passes (1/1)
- tested a full-field expression and mixed text with a formula through the real `latex -> dvisvgm -> librsvg -> Cairo SVG` pipeline
- verified generated SVG output contains vector paths and no raster image element
- verified normal Ctrl+V and explicit Ctrl+Shift+V use separate paste paths

Example:

```latex
This is a formula $$\frac{-b \pm \sqrt{b^2-4ac}}{2a}$$
```